### PR TITLE
Add landing-page builder with admin panel and API

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,0 +1,10 @@
+RewriteEngine On
+RewriteCond %{REQUEST_URI} !^/assets/
+RewriteCond %{REQUEST_URI} !^/api.php$
+RewriteCond %{REQUEST_URI} !^/admin.php$
+RewriteCond %{REQUEST_URI} !^/data/
+RewriteRule ^(.*)$ index.php [L,QSA]
+
+<FilesMatch "data.json$">
+  Require all denied
+</FilesMatch>

--- a/admin.php
+++ b/admin.php
@@ -1,0 +1,341 @@
+<?php
+session_start();
+const DATA_FILE = __DIR__ . '/data/data.json';
+
+define('RATE_LIMIT_WINDOW', 60);
+define('RATE_LIMIT_MAX', 30);
+
+function read_data(): array {
+    $fp = @fopen(DATA_FILE, 'r');
+    if (!$fp) {
+        return ['config' => [], 'pages' => [], 'media' => [], 'consents' => [], 'requests' => []];
+    }
+    flock($fp, LOCK_SH);
+    $content = stream_get_contents($fp);
+    flock($fp, LOCK_UN);
+    fclose($fp);
+    $decoded = json_decode($content, true);
+    return is_array($decoded) ? $decoded : ['config' => [], 'pages' => [], 'media' => [], 'consents' => [], 'requests' => []];
+}
+
+function write_data(array $data): void {
+    $fp = fopen(DATA_FILE, 'c+');
+    if (!$fp) {
+        throw new RuntimeException('Datenbank nicht schreibbar');
+    }
+    flock($fp, LOCK_EX);
+    ftruncate($fp, 0);
+    fwrite($fp, json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE));
+    fflush($fp);
+    flock($fp, LOCK_UN);
+    fclose($fp);
+}
+
+function ensure_rate_limit(): void {
+    $now = time();
+    $window = $_SESSION['rate_window'] ?? $now;
+    $count = $_SESSION['rate_count'] ?? 0;
+    if ($now - $window > RATE_LIMIT_WINDOW) {
+        $_SESSION['rate_window'] = $now;
+        $_SESSION['rate_count'] = 1;
+        return;
+    }
+    if ($count >= RATE_LIMIT_MAX) {
+        http_response_code(429);
+        exit('Zu viele Anfragen.');
+    }
+    $_SESSION['rate_count'] = $count + 1;
+}
+
+$data = read_data();
+$config = $data['config'] ?? [];
+ensure_rate_limit();
+
+if (!isset($_SESSION['csrf'])) {
+    $_SESSION['csrf'] = bin2hex(random_bytes(16));
+}
+
+function require_login(array $config): void {
+    if (!isset($_SESSION['admin']) || $_SESSION['admin'] !== true) {
+        header('Location: /admin.php?login=1');
+        exit;
+    }
+}
+
+if (isset($_POST['action']) && $_POST['action'] === 'login') {
+    $email = filter_input(INPUT_POST, 'email', FILTER_VALIDATE_EMAIL);
+    $password = $_POST['password'] ?? '';
+    if ($email && $password && $config['admin_user']['email'] === $email && password_verify($password, $config['admin_user']['password_hash'] ?? '')) {
+        $_SESSION['admin'] = true;
+        header('Location: /admin.php');
+        exit;
+    }
+    $error = 'Ungültige Zugangsdaten';
+}
+
+if (isset($_GET['logout'])) {
+    session_destroy();
+    header('Location: /admin.php?login=1');
+    exit;
+}
+
+if (isset($_POST['action']) && $_POST['action'] === 'save_config') {
+    require_login($config);
+    if (!hash_equals($_SESSION['csrf'], $_POST['csrf'] ?? '')) {
+        exit('Ungültiges Token');
+    }
+    $config['site_name'] = htmlspecialchars(trim($_POST['site_name'] ?? ''), ENT_QUOTES);
+    $config['seo']['title'] = htmlspecialchars(trim($_POST['seo_title'] ?? ''), ENT_QUOTES);
+    $config['seo']['description'] = htmlspecialchars(trim($_POST['seo_description'] ?? ''), ENT_QUOTES);
+    $config['openai']['api_key'] = trim($_POST['openai_key'] ?? '');
+    $config['openai']['model'] = 'gpt-4o-mini';
+    $config['openai']['temperature'] = (float)($_POST['openai_temperature'] ?? 0.7);
+    $config['openai']['prompt_template'] = trim($_POST['openai_prompt'] ?? $config['openai']['prompt_template']);
+    $data['config'] = $config;
+    write_data($data);
+    header('Location: /admin.php?saved=1');
+    exit;
+}
+
+if (isset($_POST['action']) && $_POST['action'] === 'save_page') {
+    require_login($config);
+    if (!hash_equals($_SESSION['csrf'], $_POST['csrf'] ?? '')) {
+        exit('Ungültiges Token');
+    }
+    $pageId = $_POST['page_id'] ?? bin2hex(random_bytes(6));
+    $isNew = true;
+    foreach ($data['pages'] as &$page) {
+        if (($page['id'] ?? '') === $pageId) {
+            $isNew = false;
+            $pageRef =& $page;
+            break;
+        }
+    }
+    if (!isset($pageRef)) {
+        $pageRef = [];
+        $data['pages'][] =& $pageRef;
+    $pageRef = &$data['pages'][array_key_last($data['pages'])];
+    }
+    $pageRef['id'] = $pageId;
+    $pageRef['type'] = $_POST['page_type'] ?? 'landing';
+    $pageRef['slug'] = preg_replace('/[^a-z0-9\-]/', '', strtolower($_POST['slug'] ?? ''));
+    $pageRef['title'] = trim($_POST['title'] ?? '');
+    $pageRef['subtitle'] = trim($_POST['subtitle'] ?? '');
+    $pageRef['intro'] = trim($_POST['intro'] ?? '');
+    $pageRef['long_description'] = trim($_POST['long_description'] ?? '');
+    $pageRef['hero_image'] = trim($_POST['hero_image'] ?? '');
+    $pageRef['status'] = in_array($_POST['status'] ?? 'draft', ['draft', 'published'], true) ? $_POST['status'] : 'draft';
+    $pageRef['meta'] = [
+        'title' => trim($_POST['meta_title'] ?? ''),
+        'description' => trim($_POST['meta_description'] ?? ''),
+        'canonical' => trim($_POST['meta_canonical'] ?? '')
+    ];
+    $pageRef['benefits'] = json_decode($_POST['benefits'] ?? '[]', true) ?: [];
+    $pageRef['pricing'] = json_decode($_POST['pricing'] ?? '[]', true) ?: [];
+    $pageRef['faq'] = json_decode($_POST['faq'] ?? '[]', true) ?: [];
+    $pageRef['gallery'] = json_decode($_POST['gallery'] ?? '[]', true) ?: [];
+    write_data($data);
+    unset($pageRef);
+    header('Location: /admin.php?page=' . urlencode($pageId) . '&saved=1');
+    exit;
+}
+
+if (isset($_POST['action']) && $_POST['action'] === 'delete_page') {
+    require_login($config);
+    if (!hash_equals($_SESSION['csrf'], $_POST['csrf'] ?? '')) {
+        exit('Ungültiges Token');
+    }
+    $pageId = $_POST['page_id'] ?? '';
+    $data['pages'] = array_values(array_filter($data['pages'], fn($p) => ($p['id'] ?? '') !== $pageId));
+    write_data($data);
+    header('Location: /admin.php?deleted=1');
+    exit;
+}
+
+if (isset($_POST['action']) && $_POST['action'] === 'duplicate_page') {
+    require_login($config);
+    if (!hash_equals($_SESSION['csrf'], $_POST['csrf'] ?? '')) {
+        exit('Ungültiges Token');
+    }
+    $pageId = $_POST['page_id'] ?? '';
+    foreach ($data['pages'] as $page) {
+        if (($page['id'] ?? '') === $pageId) {
+            $copy = $page;
+            $copy['id'] = bin2hex(random_bytes(6));
+            $copy['slug'] = $copy['slug'] . '-copy';
+            $copy['status'] = 'draft';
+            $data['pages'][] = $copy;
+            write_data($data);
+            header('Location: /admin.php?page=' . urlencode($copy['id']));
+            exit;
+        }
+    }
+    header('Location: /admin.php?error=notfound');
+    exit;
+}
+
+$loggedIn = isset($_SESSION['admin']) && $_SESSION['admin'] === true;
+
+function page_count(array $pages, string $type): int {
+    return count(array_filter($pages, fn($p) => ($p['type'] ?? '') === $type));
+}
+
+if (!$loggedIn) {
+    ?>
+    <!DOCTYPE html>
+    <html lang="de">
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <title>Admin Login</title>
+        <link rel="stylesheet" href="/assets/app.css">
+    </head>
+    <body class="layout-body">
+    <div class="admin-shell">
+        <div class="admin-card">
+            <h1 class="admin-title">Login</h1>
+            <?php if (!empty($error)): ?><p style="color:#b50808;"><?= htmlspecialchars($error, ENT_QUOTES) ?></p><?php endif; ?>
+            <form method="post">
+                <input type="hidden" name="action" value="login">
+                <div class="lf-field-row">
+                    <label class="lf-label">E-Mail</label>
+                    <input class="lf-input" type="email" name="email" required>
+                </div>
+                <div class="lf-field-row">
+                    <label class="lf-label">Passwort</label>
+                    <input class="lf-input" type="password" name="password" required>
+                </div>
+                <button class="admin-button" type="submit">Anmelden</button>
+            </form>
+        </div>
+    </div>
+    </body>
+    </html>
+    <?php
+    exit;
+}
+
+$selectedPageId = $_GET['page'] ?? '';
+$selectedPage = null;
+foreach ($data['pages'] as $page) {
+    if (($page['id'] ?? '') === $selectedPageId) {
+        $selectedPage = $page;
+        break;
+    }
+}
+
+?>
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Admin Panel</title>
+    <link rel="stylesheet" href="/assets/app.css">
+    <script src="/assets/app.js" defer></script>
+</head>
+<body class="layout-body">
+<div class="admin-shell">
+    <div class="admin-card">
+        <h1 class="admin-title">Dashboard</h1>
+        <div class="admin-grid">
+            <div class="admin-stat">Landings: <?= page_count($data['pages'], 'landing') ?></div>
+            <div class="admin-stat">Portfolio: <?= page_count($data['pages'], 'portfolio') ?></div>
+            <div class="admin-stat">Consents: <?= count($data['consents'] ?? []) ?></div>
+        </div>
+        <p><a class="admin-button" href="/admin.php?logout=1">Logout</a></p>
+    </div>
+
+    <div class="admin-card">
+        <h2 class="admin-title">Seiten verwalten</h2>
+        <table class="admin-table">
+            <thead>
+            <tr><th>Titel</th><th>Slug</th><th>Status</th><th>Aktionen</th></tr>
+            </thead>
+            <tbody>
+            <?php foreach ($data['pages'] as $page): ?>
+                <tr>
+                    <td><?= htmlspecialchars($page['title'] ?? '', ENT_QUOTES) ?></td>
+                    <td><?= htmlspecialchars($page['slug'] ?? '', ENT_QUOTES) ?></td>
+                    <td><?= htmlspecialchars($page['status'] ?? 'draft', ENT_QUOTES) ?></td>
+                    <td>
+                        <a class="admin-button" href="/admin.php?page=<?= urlencode($page['id'] ?? '') ?>">Bearbeiten</a>
+                        <form method="post" style="display:inline-block" onsubmit="return confirm('Wirklich löschen?');">
+                            <input type="hidden" name="action" value="delete_page">
+                            <input type="hidden" name="csrf" value="<?= $_SESSION['csrf'] ?>">
+                            <input type="hidden" name="page_id" value="<?= htmlspecialchars($page['id'] ?? '', ENT_QUOTES) ?>">
+                            <button class="admin-button" type="submit">Löschen</button>
+                        </form>
+                        <form method="post" style="display:inline-block">
+                            <input type="hidden" name="action" value="duplicate_page">
+                            <input type="hidden" name="csrf" value="<?= $_SESSION['csrf'] ?>">
+                            <input type="hidden" name="page_id" value="<?= htmlspecialchars($page['id'] ?? '', ENT_QUOTES) ?>">
+                            <button class="admin-button" type="submit">Duplizieren</button>
+                        </form>
+                    </td>
+                </tr>
+            <?php endforeach; ?>
+            </tbody>
+        </table>
+    </div>
+
+    <div class="admin-card">
+        <h2 class="admin-title">Seite bearbeiten</h2>
+        <form method="post">
+            <input type="hidden" name="action" value="save_page">
+            <input type="hidden" name="csrf" value="<?= $_SESSION['csrf'] ?>">
+            <input type="hidden" name="page_id" value="<?= htmlspecialchars($selectedPage['id'] ?? '', ENT_QUOTES) ?>">
+            <div class="lf-field-row">
+                <label class="lf-label">Typ</label>
+                <select class="lf-input" name="page_type">
+                    <?php $types = ['landing' => 'Landing', 'home' => 'Home', 'portfolio' => 'Portfolio'];
+                    foreach ($types as $key => $label):
+                        $sel = (($selectedPage['type'] ?? 'landing') === $key) ? ' selected' : '';
+                        echo '<option value="' . $key . '"' . $sel . '>' . $label . '</option>';
+                    endforeach; ?>
+                </select>
+            </div>
+            <div class="lf-field-row"><label class="lf-label">Slug</label><input class="lf-input" name="slug" value="<?= htmlspecialchars($selectedPage['slug'] ?? '', ENT_QUOTES) ?>"></div>
+            <div class="lf-field-row"><label class="lf-label">Titel</label><input class="lf-input" name="title" value="<?= htmlspecialchars($selectedPage['title'] ?? '', ENT_QUOTES) ?>"></div>
+            <div class="lf-field-row"><label class="lf-label">Untertitel</label><input class="lf-input" name="subtitle" value="<?= htmlspecialchars($selectedPage['subtitle'] ?? '', ENT_QUOTES) ?>"></div>
+            <div class="lf-field-row"><label class="lf-label">Intro</label><textarea class="lf-textarea" id="intro" name="intro"><?= htmlspecialchars($selectedPage['intro'] ?? '', ENT_QUOTES) ?></textarea></div>
+            <button class="admin-button" type="button" data-ai-generate data-ai-target="intro" data-ai-type="intro">Generieren mit IA</button>
+            <div class="lf-field-row"><label class="lf-label">Beschreibung</label><textarea class="lf-textarea" id="long_description" name="long_description"><?= htmlspecialchars($selectedPage['long_description'] ?? '', ENT_QUOTES) ?></textarea></div>
+            <button class="admin-button" type="button" data-ai-generate data-ai-target="long_description" data-ai-type="beschreibung">Generieren mit IA</button>
+            <div class="lf-field-row"><label class="lf-label">Hero Bild</label><input class="lf-input" name="hero_image" value="<?= htmlspecialchars($selectedPage['hero_image'] ?? '', ENT_QUOTES) ?>"></div>
+            <div class="lf-field-row"><label class="lf-label">Status</label>
+                <select class="lf-input" name="status">
+                    <?php foreach (['draft' => 'Entwurf', 'published' => 'Veröffentlicht'] as $key => $label):
+                        $sel = (($selectedPage['status'] ?? 'draft') === $key) ? ' selected' : '';
+                        echo '<option value="' . $key . '"' . $sel . '>' . $label . '</option>';
+                    endforeach; ?>
+                </select>
+            </div>
+            <div class="lf-field-row"><label class="lf-label">Galerie (JSON Array)</label><textarea class="lf-textarea" name="gallery"><?= htmlspecialchars(json_encode($selectedPage['gallery'] ?? [], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES), ENT_QUOTES) ?></textarea></div>
+            <div class="lf-field-row"><label class="lf-label">Benefits (JSON Array)</label><textarea class="lf-textarea" name="benefits"><?= htmlspecialchars(json_encode($selectedPage['benefits'] ?? [], JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE), ENT_QUOTES) ?></textarea></div>
+            <div class="lf-field-row"><label class="lf-label">Pricing (JSON Array)</label><textarea class="lf-textarea" name="pricing"><?= htmlspecialchars(json_encode($selectedPage['pricing'] ?? [], JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE), ENT_QUOTES) ?></textarea></div>
+            <div class="lf-field-row"><label class="lf-label">FAQ (JSON Array)</label><textarea class="lf-textarea" name="faq"><?= htmlspecialchars(json_encode($selectedPage['faq'] ?? [], JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE), ENT_QUOTES) ?></textarea></div>
+            <div class="lf-field-row"><label class="lf-label">Meta Titel</label><input class="lf-input" name="meta_title" value="<?= htmlspecialchars($selectedPage['meta']['title'] ?? '', ENT_QUOTES) ?>"></div>
+            <div class="lf-field-row"><label class="lf-label">Meta Beschreibung</label><textarea class="lf-textarea" name="meta_description"><?= htmlspecialchars($selectedPage['meta']['description'] ?? '', ENT_QUOTES) ?></textarea></div>
+            <div class="lf-field-row"><label class="lf-label">Canonical</label><input class="lf-input" name="meta_canonical" value="<?= htmlspecialchars($selectedPage['meta']['canonical'] ?? '', ENT_QUOTES) ?>"></div>
+            <button class="admin-button" type="submit">Speichern</button>
+        </form>
+    </div>
+
+    <div class="admin-card">
+        <h2 class="admin-title">Konfiguration</h2>
+        <form method="post">
+            <input type="hidden" name="action" value="save_config">
+            <input type="hidden" name="csrf" value="<?= $_SESSION['csrf'] ?>">
+            <div class="lf-field-row"><label class="lf-label">Site Name</label><input class="lf-input" name="site_name" value="<?= htmlspecialchars($config['site_name'] ?? '', ENT_QUOTES) ?>"></div>
+            <div class="lf-field-row"><label class="lf-label">SEO Titel</label><input class="lf-input" name="seo_title" value="<?= htmlspecialchars($config['seo']['title'] ?? '', ENT_QUOTES) ?>"></div>
+            <div class="lf-field-row"><label class="lf-label">SEO Beschreibung</label><textarea class="lf-textarea" name="seo_description"><?= htmlspecialchars($config['seo']['description'] ?? '', ENT_QUOTES) ?></textarea></div>
+            <div class="lf-field-row"><label class="lf-label">OpenAI Key</label><input class="lf-input" name="openai_key" value="<?= htmlspecialchars($config['openai']['api_key'] ?? '', ENT_QUOTES) ?>"></div>
+            <div class="lf-field-row"><label class="lf-label">OpenAI Temperatur</label><input class="lf-input" name="openai_temperature" value="<?= htmlspecialchars((string)($config['openai']['temperature'] ?? 0.7), ENT_QUOTES) ?>"></div>
+            <div class="lf-field-row"><label class="lf-label">Prompt Vorlage</label><textarea class="lf-textarea" name="openai_prompt"><?= htmlspecialchars($config['openai']['prompt_template'] ?? '', ENT_QUOTES) ?></textarea></div>
+            <button class="admin-button" type="submit">Konfiguration speichern</button>
+        </form>
+    </div>
+</div>
+</body>
+</html>

--- a/api.php
+++ b/api.php
@@ -1,0 +1,184 @@
+<?php
+session_start();
+const DATA_FILE = __DIR__ . '/data/data.json';
+const RATE_WINDOW = 60;
+const RATE_MAX = 60;
+
+function read_data(): array {
+    $fp = @fopen(DATA_FILE, 'r');
+    if (!$fp) {
+        return ['config' => [], 'pages' => [], 'media' => [], 'consents' => [], 'requests' => []];
+    }
+    flock($fp, LOCK_SH);
+    $content = stream_get_contents($fp);
+    flock($fp, LOCK_UN);
+    fclose($fp);
+    $decoded = json_decode($content, true);
+    return is_array($decoded) ? $decoded : ['config' => [], 'pages' => [], 'media' => [], 'consents' => [], 'requests' => []];
+}
+
+function write_data(array $data): void {
+    $fp = fopen(DATA_FILE, 'c+');
+    if (!$fp) {
+        throw new RuntimeException('Datenbank nicht schreibbar');
+    }
+    flock($fp, LOCK_EX);
+    ftruncate($fp, 0);
+    fwrite($fp, json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE));
+    fflush($fp);
+    flock($fp, LOCK_UN);
+    fclose($fp);
+}
+
+function ensure_rate_limit(): void {
+    $now = time();
+    $window = $_SESSION['api_window'] ?? $now;
+    $count = $_SESSION['api_count'] ?? 0;
+    if ($now - $window > RATE_WINDOW) {
+        $_SESSION['api_window'] = $now;
+        $_SESSION['api_count'] = 1;
+        return;
+    }
+    if ($count >= RATE_MAX) {
+        http_response_code(429);
+        header('Content-Type: application/json');
+        echo json_encode(['success' => false, 'error' => 'rate_limited']);
+        exit;
+    }
+    $_SESSION['api_count'] = $count + 1;
+}
+
+function respond(array $payload): void {
+    header('Content-Type: application/json');
+    echo json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+    exit;
+}
+
+ensure_rate_limit();
+
+$method = $_SERVER['REQUEST_METHOD'] ?? 'GET';
+$data = read_data();
+$config = $data['config'] ?? [];
+
+if ($method === 'POST') {
+    $raw = file_get_contents('php://input');
+    $payload = json_decode($raw, true);
+    if (!is_array($payload)) {
+        $payload = $_POST;
+    }
+    $action = $payload['action'] ?? ($_GET['action'] ?? '');
+} else {
+    $payload = $_GET;
+    $action = $_GET['action'] ?? '';
+}
+
+switch ($action) {
+    case 'consent.accept':
+        $version = $payload['payload']['version'] ?? ($config['legal']['policy_version'] ?? '1');
+        $ipHash = hash('sha256', ($_SERVER['REMOTE_ADDR'] ?? '0.0.0.0') . $_SERVER['HTTP_USER_AGENT']);
+        $data['consents'][] = [
+            'version' => $version,
+            'ip_hash' => $ipHash,
+            'timestamp' => gmdate('c')
+        ];
+        write_data($data);
+        respond(['success' => true]);
+        break;
+
+    case 'ai.generate':
+        if (!isset($_SESSION['admin']) || $_SESSION['admin'] !== true) {
+            respond(['success' => false, 'error' => 'unauthorized']);
+        }
+        $type = $payload['payload']['type'] ?? 'text';
+        $promptBase = $config['openai']['prompt_template'] ?? '';
+        $prompt = strtr($promptBase, [
+            '{category}' => $payload['payload']['category'] ?? 'Fotoshooting',
+            '{tone}' => $payload['payload']['tone'] ?? 'warm',
+            '{audience}' => $payload['payload']['audience'] ?? 'Familien',
+            '{keywords}' => $payload['payload']['keywords'] ?? ''
+        ]);
+        $prompt .= "\nBitte generiere einen kurzen Abschnitt für: " . $type;
+        $apiKey = $config['openai']['api_key'] ?? '';
+        if (!$apiKey) {
+            respond(['success' => true, 'text' => 'Bitte trage zuerst einen OpenAI API Key ein.']);
+        }
+        $ch = curl_init('https://api.openai.com/v1/responses');
+        $request = [
+            'model' => $config['openai']['model'] ?? 'gpt-4o-mini',
+            'input' => $prompt,
+            'temperature' => $config['openai']['temperature'] ?? 0.7
+        ];
+        curl_setopt_array($ch, [
+            CURLOPT_POST => true,
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_HTTPHEADER => [
+                'Content-Type: application/json',
+                'Authorization: Bearer ' . $apiKey
+            ],
+            CURLOPT_POSTFIELDS => json_encode($request)
+        ]);
+        $response = curl_exec($ch);
+        if ($response === false) {
+            curl_close($ch);
+            respond(['success' => false, 'error' => 'curl_error']);
+        }
+        curl_close($ch);
+        $decoded = json_decode($response, true);
+        $text = $decoded['output'][0]['content'][0]['text'] ?? ($decoded['choices'][0]['text'] ?? '');
+        respond(['success' => true, 'text' => trim($text)]);
+        break;
+
+    case 'form.submit':
+        if ($method !== 'POST') {
+            respond(['success' => false, 'error' => 'invalid_method']);
+        }
+        $email = filter_input(INPUT_POST, 'email', FILTER_VALIDATE_EMAIL);
+        $name = htmlspecialchars(trim($_POST['name'] ?? ''), ENT_QUOTES);
+        if (!$email || !$name) {
+            respond(['success' => false, 'error' => 'validation']);
+        }
+        $slug = $_GET['slug'] ?? '';
+        $entry = [
+            'slug' => $slug,
+            'name' => $name,
+            'email' => $email,
+            'category' => htmlspecialchars(trim($_POST['category'] ?? ''), ENT_QUOTES),
+            'source' => htmlspecialchars(trim($_POST['source'] ?? ''), ENT_QUOTES),
+            'details' => htmlspecialchars(trim($_POST['details'] ?? ''), ENT_QUOTES),
+            'date' => $_POST['date'] ?? '',
+            'options' => array_map(fn($opt) => htmlspecialchars($opt, ENT_QUOTES), $_POST['options'] ?? []),
+            'message' => htmlspecialchars(trim($_POST['message'] ?? ''), ENT_QUOTES),
+            'timestamp' => gmdate('c')
+        ];
+        $data['requests'][] = $entry;
+        write_data($data);
+        $isAjax = isset($_SERVER['HTTP_ACCEPT']) && strpos($_SERVER['HTTP_ACCEPT'], 'application/json') !== false;
+        if ($isAjax) {
+            respond(['success' => true, 'message' => 'Danke für deine Anfrage!']);
+        }
+        header('Location: /form/' . urlencode($slug) . '?sent=1');
+        exit;
+        break;
+
+    case 'export.request':
+        $email = filter_var($payload['email'] ?? '', FILTER_VALIDATE_EMAIL);
+        if (!$email) {
+            respond(['success' => false, 'error' => 'invalid_email']);
+        }
+        $matches = array_values(array_filter($data['requests'] ?? [], fn($r) => ($r['email'] ?? '') === $email));
+        respond(['success' => true, 'data' => $matches]);
+        break;
+
+    case 'delete.request':
+        $email = filter_var($payload['email'] ?? '', FILTER_VALIDATE_EMAIL);
+        if (!$email) {
+            respond(['success' => false, 'error' => 'invalid_email']);
+        }
+        $data['requests'] = array_values(array_filter($data['requests'] ?? [], fn($r) => ($r['email'] ?? '') !== $email));
+        write_data($data);
+        respond(['success' => true]);
+        break;
+
+    default:
+        respond(['success' => false, 'error' => 'unknown_action']);
+}

--- a/assets/app.css
+++ b/assets/app.css
@@ -1,0 +1,68 @@
+.layout-body { font-family: 'Montserrat', sans-serif; color: #1a1a1a; background-color: #ffffff; margin: 0; }
+.layout-wrap { max-width: 80%; margin: 0 auto; }
+.header-top { display: flex; justify-content: space-between; align-items: center; padding: 24px 0; }
+.header-logo { height: 60px; }
+.nav-links { display: flex; gap: 24px; font-size: 14px; letter-spacing: 0.08em; text-transform: uppercase; }
+.nav-link { color: #1a1a1a; text-decoration: none; }
+.nav-link:hover { color: #b50808; }
+.lp-shell { max-width: 80%; margin: 0 auto; padding-bottom: 80px; }
+.lp-hero { position: relative; background-size: cover; background-position: center; min-height: 460px; display: flex; align-items: flex-end; }
+.lp-hero::after { content: ""; position: absolute; inset: 0; background: linear-gradient(180deg, rgba(0,0,0,0.15) 0%, rgba(0,0,0,0.55) 85%); }
+.lp-hero-inner { position: relative; z-index: 1; padding: 48px; color: #ffffff; max-width: 580px; }
+.lp-hero-badge { display: inline-flex; align-items: center; gap: 12px; background-color: rgba(181,8,8,0.85); padding: 8px 16px; font-size: 12px; letter-spacing: 0.12em; text-transform: uppercase; }
+.lp-hero-title { font-size: 40px; margin: 18px 0 12px; letter-spacing: 0.08em; }
+.lp-hero-subtitle { font-size: 22px; margin: 0 0 16px; font-weight: 500; }
+.lp-hero-text { font-size: 16px; line-height: 1.6; margin: 0 0 24px; }
+.lp-button { display: inline-block; padding: 14px 36px; background-color: #b50808; color: #ffffff; text-decoration: none; letter-spacing: 0.08em; text-transform: uppercase; font-weight: 600; border-radius: 4px; }
+.lp-button:hover { background-color: #8c0606; }
+.lp-section { margin: 60px 0; }
+.lp-section-title { font-size: 28px; letter-spacing: 0.12em; text-transform: uppercase; margin-bottom: 28px; text-align: center; }
+.lp-gallery-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); gap: 18px; }
+.lp-gallery-item { position: relative; overflow: hidden; border-radius: 8px; }
+.lp-gallery-image { width: 100%; height: 260px; object-fit: cover; display: block; }
+.lp-benefit-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); gap: 28px; }
+.lp-benefit-card { background: #f6f3f0; padding: 24px; border-radius: 8px; }
+.lp-benefit-title { font-size: 18px; margin-bottom: 12px; letter-spacing: 0.06em; text-transform: uppercase; color: #b50808; }
+.lp-benefit-text { line-height: 1.6; }
+.lp-textblock-content { background: #fff9f7; padding: 32px; border-radius: 8px; line-height: 1.7; }
+.lp-pricing-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap: 24px; }
+.lp-price-card { border: 2px solid #b50808; padding: 28px; border-radius: 8px; background: #ffffff; }
+.lp-price-name { font-size: 18px; letter-spacing: 0.08em; text-transform: uppercase; margin-bottom: 12px; color: #b50808; }
+.lp-price-value { font-size: 32px; margin: 0 0 12px; }
+.lp-faq-item { border-bottom: 1px solid #e5dad6; padding: 16px 0; }
+.lp-faq-question { font-weight: 600; letter-spacing: 0.04em; }
+.lp-faq-answer { margin-top: 8px; line-height: 1.6; }
+.lp-cta { text-align: center; background: #1a1a1a; padding: 48px; border-radius: 8px; }
+.lp-cta-text { color: #ffffff; font-size: 22px; margin-bottom: 24px; letter-spacing: 0.04em; }
+.lf-shell { max-width: 80%; margin: 0 auto; padding: 64px 0; }
+.lf-header { text-align: center; }
+.lf-logo { height: 80px; margin-bottom: 16px; }
+.lf-title { font-size: 32px; letter-spacing: 0.12em; text-transform: uppercase; }
+.lf-subtitle { font-size: 16px; color: #5a5a5a; }
+.lf-form { background: #1a1a1a; padding: 48px; border-radius: 8px; margin-top: 32px; }
+.lf-field-row { margin-bottom: 24px; }
+.lf-label { display: block; color: #f7f3f0; letter-spacing: 0.06em; text-transform: uppercase; margin-bottom: 12px; font-size: 13px; }
+.lf-input { width: 90%; padding: 14px; border: 1px solid #b50808; background: #b50808; color: #ffffff; border-radius: 4px; }
+.lf-textarea { width: 90%; padding: 14px; border: 1px solid #b50808; background: #b50808; color: #ffffff; border-radius: 4px; resize: vertical; }
+.lf-input::placeholder, .lf-textarea::placeholder { color: rgba(255,255,255,0.8); }
+.lf-checkboxes { color: #ffffff; }
+.lf-checkbox-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 12px; }
+.lf-checkbox { display: flex; align-items: center; gap: 10px; background: rgba(255,255,255,0.05); padding: 12px; border-radius: 4px; border: 1px solid rgba(255,255,255,0.15); }
+.lf-checkbox input { accent-color: #b50808; }
+.lf-consent { margin: 24px 0; }
+.lf-consent-label { color: #ffffff; font-size: 13px; display: flex; align-items: flex-start; gap: 10px; }
+.lf-submit { background: #b50808; color: #ffffff; border: none; padding: 16px 40px; text-transform: uppercase; letter-spacing: 0.12em; cursor: pointer; border-radius: 4px; }
+.lf-submit:hover { background: #8c0606; }
+.lf-footer { margin-top: 40px; text-align: center; color: #777777; font-size: 12px; letter-spacing: 0.08em; text-transform: uppercase; }
+.consent-banner { position: fixed; inset: auto 0 0 0; background: #1a1a1a; color: #ffffff; padding: 16px; display: none; align-items: center; justify-content: space-between; gap: 18px; }
+.consent-banner-active { display: flex; }
+.consent-banner button { background: #b50808; color: #ffffff; border: none; padding: 12px 24px; text-transform: uppercase; letter-spacing: 0.1em; cursor: pointer; border-radius: 4px; }
+.admin-shell { max-width: 80%; margin: 40px auto; font-family: 'Montserrat', sans-serif; }
+.admin-card { background: #ffffff; border: 1px solid #efe1d8; border-radius: 8px; padding: 32px; margin-bottom: 32px; }
+.admin-title { text-transform: uppercase; letter-spacing: 0.12em; margin-bottom: 24px; font-size: 20px; }
+.admin-table { width: 100%; border-collapse: collapse; }
+.admin-table th, .admin-table td { padding: 12px; border-bottom: 1px solid #f0e6dd; text-align: left; }
+.admin-button { background: #b50808; color: #ffffff; padding: 10px 20px; text-decoration: none; text-transform: uppercase; letter-spacing: 0.08em; border-radius: 4px; border: none; cursor: pointer; }
+.admin-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap: 24px; }
+.admin-stat { background: #f6f3f0; padding: 24px; border-radius: 8px; text-transform: uppercase; letter-spacing: 0.08em; }
+.csrf-field { display: none; }

--- a/assets/app.js
+++ b/assets/app.js
@@ -1,0 +1,57 @@
+(function() {
+  const consentKey = 'lb_consent';
+  const banner = document.querySelector('.consent-banner');
+  const acceptBtn = document.querySelector('.consent-accept');
+  if (banner && acceptBtn && navigator.doNotTrack !== '1') {
+    const saved = localStorage.getItem(consentKey);
+    if (!saved) {
+      banner.classList.add('consent-banner-active');
+    }
+    acceptBtn.addEventListener('click', function() {
+      fetch('/api.php', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ action: 'consent.accept', payload: { version: banner.dataset.version } })
+      }).then(function(resp) { return resp.json(); }).then(function(data) {
+        if (data.success) {
+          localStorage.setItem(consentKey, JSON.stringify({ ts: Date.now(), version: banner.dataset.version }));
+          banner.classList.remove('consent-banner-active');
+        }
+      }).catch(function() { banner.classList.remove('consent-banner-active'); });
+    });
+  }
+
+  document.querySelectorAll('[data-ai-generate]').forEach(function(button) {
+    button.addEventListener('click', function() {
+      const targetId = this.dataset.aiTarget;
+      const textarea = document.getElementById(targetId);
+      const type = this.dataset.aiType;
+      if (!textarea) { return; }
+      button.disabled = true;
+      const params = {
+        action: 'ai.generate',
+        payload: {
+          type: type,
+          text: textarea.value,
+          category: this.dataset.aiCategory || '',
+          tone: this.dataset.aiTone || 'warm',
+          audience: this.dataset.aiAudience || 'familien',
+          keywords: this.dataset.aiKeywords || ''
+        }
+      };
+      fetch('/api.php', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify(params)
+      }).then(function(resp) { return resp.json(); }).then(function(data) {
+        if (data.success && data.text) {
+          textarea.value = data.text;
+        }
+      }).finally(function() {
+        button.disabled = false;
+      });
+    });
+  });
+})();

--- a/data/data.json
+++ b/data/data.json
@@ -1,0 +1,111 @@
+{
+  "config": {
+    "site_name": "Liebesblick Fotografie",
+    "base_url": "http://localhost",
+    "default_locale": "de-DE",
+    "openai": {
+      "api_key": "",
+      "model": "gpt-4o-mini",
+      "temperature": 0.7,
+      "prompt_template": "Erstelle überzeugende Texte für eine Landing Page zur Kategorie {category} im Ton {tone} für die Zielgruppe {audience}. Nutze folgende Stichworte: {keywords}."
+    },
+    "seo": {
+      "title": "Emotionale Fotoshootings in Deutschland",
+      "description": "Professionelle Familien- und Babyfotografie mit Herz.",
+      "keywords": "Fotostudio, Familienfotos, Babyfotos"
+    },
+    "legal": {
+      "impressum": "<h2>Impressum</h2><p>Liebesblick Fotografie<br>Inhaber: Delina Hartmann<br>Musterstraße 1<br>12345 Berlin</p>",
+      "privacy": "<h2>Datenschutzerklärung</h2><p>Wir verarbeiten personenbezogene Daten gemäß DSGVO.</p>",
+      "policy_version": "2024-01"
+    },
+    "admin_user": {
+      "email": "admin@example.com",
+      "password_hash": "$2y$10$xtY60p.PLMGIXevqxetUIeRbIY6uICNC/MAOhrGPWCR0/vmSI9A4O"
+    }
+  },
+  "pages": [
+    {
+      "id": "home",
+      "type": "home",
+      "slug": "",
+      "title": "Liebevolle Fotografie für jede Lebensphase",
+      "subtitle": "Zeitlose Erinnerungen voller Wärme.",
+      "hero_image": "assets/images/hero-home.jpg",
+      "gallery": [
+        "assets/images/sample1.jpg",
+        "assets/images/sample2.jpg",
+        "assets/images/sample3.jpg"
+      ],
+      "benefits": [
+        {"title": "Natürliche Emotionen", "description": "Wir fangen echte Gefühle mit viel Feingefühl ein."},
+        {"title": "Flexible Pakete", "description": "Individuell zugeschnittene Shootings für jede Familie."},
+        {"title": "Schnelle Bearbeitung", "description": "Fertige Galerien innerhalb von 5 Werktagen."}
+      ],
+      "faq": [
+        {"q": "Wo finden die Shootings statt?", "a": "In unserem Studio oder an Lieblingsorten in Berlin."},
+        {"q": "Was sollen wir anziehen?", "a": "Harmonische Farben ohne große Muster sind ideal."}
+      ],
+      "status": "published",
+      "meta": {
+        "title": "Liebesblick Fotografie | Emotionale Bilder",
+        "description": "Babybauch-, Newborn- und Familienshootings, die berühren.",
+        "canonical": "/"
+      }
+    },
+    {
+      "id": "portfolio",
+      "type": "portfolio",
+      "slug": "portfolio",
+      "title": "Portfolio",
+      "subtitle": "Einblicke in unsere Shootings",
+      "hero_image": "assets/images/portfolio-hero.jpg",
+      "gallery": [
+        "assets/images/portfolio1.jpg",
+        "assets/images/portfolio2.jpg",
+        "assets/images/portfolio3.jpg"
+      ],
+      "status": "published",
+      "meta": {
+        "title": "Portfolio | Liebesblick Fotografie",
+        "description": "Lerne unsere beliebtesten Foto-Collections kennen.",
+        "canonical": "/portfolio"
+      }
+    },
+    {
+      "id": "weihnachten-mini",
+      "type": "landing",
+      "slug": "weihnachtsminis-2024",
+      "title": "WEIHNACHTSMINIS 2024",
+      "subtitle": "Tageslichstudio in Kleinmachnow",
+      "hero_image": "assets/images/landing-hero.jpg",
+      "gallery": [
+        "assets/images/landing1.jpg",
+        "assets/images/landing2.jpg",
+        "assets/images/landing3.jpg"
+      ],
+      "benefits": [
+        {"title": "Stimmungsvolle Kulisse", "description": "Warme Naturtöne, goldene Akzente und gemütliche Sets."},
+        {"title": "15 Minuten Shooting", "description": "Perfekt für Familien mit kleinen Kindern."},
+        {"title": "15 professionell bearbeitete Fotos", "description": "Lieferung innerhalb von 3 Werktagen."}
+      ],
+      "faq": [
+        {"q": "Wie viele Personen können teilnehmen?", "a": "Bis zu 5 Personen pro Termin."},
+        {"q": "Gibt es Parkplätze?", "a": "Kostenlose Parkplätze direkt vor dem Studio."}
+      ],
+      "pricing": [
+        {"name": "Mini Paket", "price": "149€", "description": "15 Minuten Shooting, 5 Bilder"},
+        {"name": "Classic Paket", "price": "219€", "description": "25 Minuten Shooting, 15 Bilder"}
+      ],
+      "status": "published",
+      "meta": {
+        "title": "Weihnachtsminis 2024 | Liebesblick Fotografie",
+        "description": "Magische Weihnachtsfotoshootings in gemütlicher Atmosphäre.",
+        "canonical": "/l/weihnachtsminis-2024"
+      }
+    }
+  ],
+  "media": [],
+  "consents": [],
+  "requests": []
+}

--- a/index.php
+++ b/index.php
@@ -1,0 +1,339 @@
+<?php
+session_start();
+const DATA_FILE = __DIR__ . '/data/data.json';
+
+function read_data(): array {
+    $fp = @fopen(DATA_FILE, 'r');
+    if (!$fp) {
+        return ['config' => [], 'pages' => [], 'media' => [], 'consents' => [], 'requests' => []];
+    }
+    flock($fp, LOCK_SH);
+    $content = stream_get_contents($fp);
+    flock($fp, LOCK_UN);
+    fclose($fp);
+    $decoded = json_decode($content, true);
+    return is_array($decoded) ? $decoded : ['config' => [], 'pages' => [], 'media' => [], 'consents' => [], 'requests' => []];
+}
+
+function render_template(string $html, array $vars = []): string {
+    foreach ($vars as $key => $value) {
+        $html = str_replace('{{' . $key . '}}', $value, $html);
+    }
+    return $html;
+}
+
+function page_meta(array $config, array $page): array {
+    $meta = $page['meta'] ?? [];
+    $globalTitle = $config['seo']['title'] ?? '';
+    $title = $meta['title'] ?? $globalTitle;
+    $description = $meta['description'] ?? ($config['seo']['description'] ?? '');
+    $canonical = ($config['base_url'] ?? '') . ($meta['canonical'] ?? '/');
+    return compact('title', 'description', 'canonical');
+}
+
+function per_page_css(string $type): string {
+    return $type === 'form'
+        ? '.lf-shell{max-width:80%;margin:0 auto;padding:32px 0;}'
+        : '.lp-shell{max-width:80%;margin:0 auto;}';
+}
+
+function schema_org(array $config, array $page, string $url): string {
+    $org = [
+        '@context' => 'https://schema.org',
+        '@type' => 'Organization',
+        'name' => $config['site_name'] ?? 'Liebesblick Fotografie',
+        'url' => $config['base_url'] ?? '',
+        'logo' => ($config['base_url'] ?? '') . '/assets/images/logo.svg'
+    ];
+    $service = [
+        '@context' => 'https://schema.org',
+        '@type' => ($page['type'] ?? '') === 'landing' ? 'Service' : 'Product',
+        'name' => $page['title'] ?? 'Fotoshooting',
+        'description' => $page['subtitle'] ?? '',
+        'provider' => ['@type' => 'Organization', 'name' => $config['site_name'] ?? 'Liebesblick Fotografie']
+    ];
+    $faqItems = [];
+    foreach ($page['faq'] ?? [] as $item) {
+        $faqItems[] = [
+            '@type' => 'Question',
+            'name' => $item['q'],
+            'acceptedAnswer' => ['@type' => 'Answer', 'text' => $item['a']]
+        ];
+    }
+    $faq = [
+        '@context' => 'https://schema.org',
+        '@type' => 'FAQPage',
+        'mainEntity' => $faqItems
+    ];
+    $breadcrumbs = [
+        '@context' => 'https://schema.org',
+        '@type' => 'BreadcrumbList',
+        'itemListElement' => [
+            ['@type' => 'ListItem', 'position' => 1, 'name' => 'Startseite', 'item' => $config['base_url'] ?? ''],
+            ['@type' => 'ListItem', 'position' => 2, 'name' => $page['title'] ?? 'Landing', 'item' => $url]
+        ]
+    ];
+    return json_encode([$org, $service, $faq, $breadcrumbs], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+}
+
+function find_page(array $pages, string $type, string $slug = ''): ?array {
+    foreach ($pages as $page) {
+        if (($page['type'] ?? '') !== $type) {
+            continue;
+        }
+        if ($type === 'landing' && ($page['slug'] ?? '') === $slug && ($page['status'] ?? '') === 'published') {
+            return $page;
+        }
+        if ($type === 'home' && ($page['id'] ?? '') === 'home') {
+            return $page;
+        }
+        if ($type === 'portfolio' && (($page['slug'] ?? '') === $slug || ($page['id'] ?? '') === 'portfolio')) {
+            return $page;
+        }
+    }
+    return null;
+}
+
+function gallery_markup(array $images): string {
+    $items = [];
+    foreach ($images as $img) {
+        $safe = htmlspecialchars($img, ENT_QUOTES);
+        $items[] = '<figure class="lp-gallery-item"><img loading="lazy" class="lp-gallery-image" src="' . $safe . '" alt="Galerie"></figure>';
+    }
+    return implode("\n", $items);
+}
+
+function benefits_markup(array $benefits): string {
+    $items = [];
+    foreach ($benefits as $benefit) {
+        $items[] = '<article class="lp-benefit-card"><h4 class="lp-benefit-title">' . htmlspecialchars($benefit['title'], ENT_QUOTES) . '</h4><p class="lp-benefit-text">' . htmlspecialchars($benefit['description'], ENT_QUOTES) . '</p></article>';
+    }
+    return implode("\n", $items);
+}
+
+function pricing_markup(array $pricing): string {
+    $items = [];
+    foreach ($pricing as $price) {
+        $items[] = '<div class="lp-price-card"><h4 class="lp-price-name">' . htmlspecialchars($price['name'], ENT_QUOTES) . '</h4><p class="lp-price-value">' . htmlspecialchars($price['price'], ENT_QUOTES) . '</p><p>' . htmlspecialchars($price['description'], ENT_QUOTES) . '</p></div>';
+    }
+    return implode("\n", $items);
+}
+
+function faq_markup(array $faq): string {
+    $items = [];
+    foreach ($faq as $entry) {
+        $items[] = '<div class="lp-faq-item"><p class="lp-faq-question">' . htmlspecialchars($entry['q'], ENT_QUOTES) . '</p><p class="lp-faq-answer">' . htmlspecialchars($entry['a'], ENT_QUOTES) . '</p></div>';
+    }
+    return implode("\n", $items);
+}
+
+function legal_page(array $meta, string $content, array $config): void {
+    $critical = '.layout-wrap{max-width:80%;margin:0 auto;}';
+    $schema = json_encode([[
+        '@context' => 'https://schema.org',
+        '@type' => 'Organization',
+        'name' => $config['site_name'] ?? 'Liebesblick Fotografie',
+        'url' => $config['base_url'] ?? ''
+    ]], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+    $consentVersion = htmlspecialchars($config['legal']['policy_version'] ?? '1', ENT_QUOTES);
+    $url = $meta['canonical'];
+    echo '<!DOCTYPE html><html lang="de"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">';
+    echo '<title>' . htmlspecialchars($meta['title'], ENT_QUOTES) . '</title>';
+    echo '<meta name="description" content="' . htmlspecialchars($meta['description'], ENT_QUOTES) . '">';
+    echo '<link rel="canonical" href="' . htmlspecialchars($meta['canonical'], ENT_QUOTES) . '">';
+    echo '<meta property="og:title" content="' . htmlspecialchars($meta['title'], ENT_QUOTES) . '">';
+    echo '<meta property="og:description" content="' . htmlspecialchars($meta['description'], ENT_QUOTES) . '">';
+    echo '<meta property="og:type" content="website">';
+    echo '<meta property="og:url" content="' . htmlspecialchars($url, ENT_QUOTES) . '">';
+    echo '<meta property="twitter:card" content="summary_large_image">';
+    echo '<meta property="twitter:title" content="' . htmlspecialchars($meta['title'], ENT_QUOTES) . '">';
+    echo '<meta property="twitter:description" content="' . htmlspecialchars($meta['description'], ENT_QUOTES) . '">';
+    echo '<link rel="alternate" hreflang="de-DE" href="' . htmlspecialchars($url, ENT_QUOTES) . '">';
+    echo '<style>' . $critical . '</style>';
+    echo '<link rel="preload" href="/assets/app.css" as="style">';
+    echo '<link rel="stylesheet" href="/assets/app.css" media="print" onload="this.media=\'all\'">';
+    echo '<noscript><link rel="stylesheet" href="/assets/app.css"></noscript>';
+    echo '<script type="application/ld+json">' . $schema . '</script>';
+    echo '</head><body class="layout-body"><div class="layout-wrap"><header class="header-top">';
+    echo '<img src="/assets/images/logo.svg" alt="Liebesblick" class="header-logo">';
+    echo '<nav class="nav-links"><a class="nav-link" href="/">Startseite</a><a class="nav-link" href="/portfolio">Portfolio</a><a class="nav-link" href="/impressum">Impressum</a><a class="nav-link" href="/datenschutz">Datenschutz</a></nav>';
+    echo '</header></div><main class="layout-wrap">' . $content . '</main>';
+    echo '<div class="consent-banner" data-version="' . $consentVersion . '"><p>Wir verwenden ausschließlich notwendige Cookies. Mehr erfährst du in unserer <a href="/datenschutz" style="color:#fff;text-decoration:underline;">Datenschutzerklärung</a>.</p><button class="consent-accept">Zustimmen</button></div>';
+    echo '<script src="/assets/app.js" defer></script></body></html>';
+}
+
+$data = read_data();
+$config = $data['config'] ?? [];
+$pages = $data['pages'] ?? [];
+$uri = parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH) ?: '/';
+
+if ($uri === '/sitemap.xml') {
+    header('Content-Type: application/xml; charset=utf-8');
+    $base = rtrim($config['base_url'] ?? '', '/');
+    $urls = [$base . '/', $base . '/portfolio', $base . '/impressum', $base . '/datenschutz'];
+    foreach ($pages as $page) {
+        if (($page['type'] ?? '') === 'landing' && ($page['status'] ?? '') === 'published') {
+            $urls[] = $base . '/l/' . $page['slug'];
+            $urls[] = $base . '/form/' . $page['slug'];
+        }
+    }
+    echo '<?xml version="1.0" encoding="UTF-8"?>';
+    echo '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">';
+    foreach ($urls as $url) {
+        echo '<url><loc>' . htmlspecialchars($url, ENT_XML1) . '</loc></url>';
+    }
+    echo '</urlset>';
+    exit;
+}
+
+if ($uri === '/robots.txt') {
+    header('Content-Type: text/plain; charset=utf-8');
+    echo "User-agent: *\nAllow: /\nSitemap: " . ($config['base_url'] ?? '') . "/sitemap.xml";
+    exit;
+}
+
+if ($uri === '/impressum') {
+    legal_page([
+        'title' => 'Impressum | ' . ($config['site_name'] ?? ''),
+        'description' => 'Rechtliche Informationen',
+        'canonical' => ($config['base_url'] ?? '') . '/impressum'
+    ], $config['legal']['impressum'] ?? '', $config);
+    exit;
+}
+
+if ($uri === '/datenschutz') {
+    legal_page([
+        'title' => 'Datenschutzerklärung | ' . ($config['site_name'] ?? ''),
+        'description' => 'Informationen zum Datenschutz',
+        'canonical' => ($config['base_url'] ?? '') . '/datenschutz'
+    ], $config['legal']['privacy'] ?? '', $config);
+    exit;
+}
+
+$type = 'home';
+$slug = '';
+$page = null;
+if ($uri === '/') {
+    $page = find_page($pages, 'home');
+} elseif ($uri === '/portfolio') {
+    $type = 'portfolio';
+    $page = find_page($pages, 'portfolio', 'portfolio');
+} elseif (preg_match('#^/l/([a-z0-9\-]+)$#', $uri, $matches)) {
+    $type = 'landing';
+    $slug = $matches[1];
+    $page = find_page($pages, 'landing', $slug);
+} elseif (preg_match('#^/form/([a-z0-9\-]+)$#', $uri, $matches)) {
+    $type = 'form';
+    $slug = $matches[1];
+    $page = find_page($pages, 'landing', $slug);
+} else {
+    http_response_code(404);
+    legal_page([
+        'title' => 'Seite nicht gefunden',
+        'description' => '404',
+        'canonical' => ($config['base_url'] ?? '') . $uri
+    ], '<h1>404</h1><p>Die angeforderte Seite wurde nicht gefunden.</p>', $config);
+    exit;
+}
+
+if (!$page) {
+    http_response_code(404);
+    legal_page([
+        'title' => 'Seite nicht gefunden',
+        'description' => '404',
+        'canonical' => ($config['base_url'] ?? '') . $uri
+    ], '<h1>404</h1><p>Die angeforderte Seite wurde nicht gefunden.</p>', $config);
+    exit;
+}
+
+$meta = page_meta($config, $page);
+$criticalCss = per_page_css($type);
+$url = rtrim($config['base_url'] ?? '', '/') . $uri;
+$schema = schema_org($config, $page, $url);
+$consentVersion = htmlspecialchars($config['legal']['policy_version'] ?? '1', ENT_QUOTES);
+
+?><!DOCTYPE html>
+<html lang="de">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title><?= htmlspecialchars($meta['title'], ENT_QUOTES) ?></title>
+<meta name="description" content="<?= htmlspecialchars($meta['description'], ENT_QUOTES) ?>">
+<link rel="canonical" href="<?= htmlspecialchars($meta['canonical'], ENT_QUOTES) ?>">
+<meta property="og:title" content="<?= htmlspecialchars($meta['title'], ENT_QUOTES) ?>">
+<meta property="og:description" content="<?= htmlspecialchars($meta['description'], ENT_QUOTES) ?>">
+<meta property="og:type" content="website">
+<meta property="og:url" content="<?= htmlspecialchars($url, ENT_QUOTES) ?>">
+<meta property="twitter:card" content="summary_large_image">
+<meta property="twitter:title" content="<?= htmlspecialchars($meta['title'], ENT_QUOTES) ?>">
+<meta property="twitter:description" content="<?= htmlspecialchars($meta['description'], ENT_QUOTES) ?>">
+<link rel="alternate" hreflang="de-DE" href="<?= htmlspecialchars($url, ENT_QUOTES) ?>">
+<style><?= $criticalCss ?></style>
+<link rel="preload" href="/assets/app.css" as="style">
+<link rel="stylesheet" href="/assets/app.css" media="print" onload="this.media='all'">
+<noscript><link rel="stylesheet" href="/assets/app.css"></noscript>
+<script type="application/ld+json"><?= $schema ?></script>
+</head>
+<body class="layout-body">
+<div class="layout-wrap">
+  <header class="header-top">
+    <img src="/assets/images/logo.svg" alt="Liebesblick" class="header-logo">
+    <nav class="nav-links">
+      <a class="nav-link" href="/">Startseite</a>
+      <a class="nav-link" href="/portfolio">Portfolio</a>
+      <a class="nav-link" href="/impressum">Impressum</a>
+      <a class="nav-link" href="/datenschutz">Datenschutz</a>
+    </nav>
+  </header>
+</div>
+<?php
+if ($type === 'form') {
+    $template = file_get_contents(__DIR__ . '/templates/form.html');
+    $successNote = isset($_GET['sent']) ? '<div class="admin-card" style="background:#f6f3f0;margin:24px auto;max-width:80%;padding:16px;">Danke für deine Nachricht!</div>' : '';
+    $categories = [];
+    foreach ($pages as $p) {
+        if (($p['type'] ?? '') === 'landing') {
+            $selected = $p['slug'] === $slug ? ' selected' : '';
+            $categories[] = '<option value="' . htmlspecialchars($p['title'], ENT_QUOTES) . '"' . $selected . '>' . htmlspecialchars($p['title'], ENT_QUOTES) . '</option>';
+        }
+    }
+    $options = ['Styling Tipps', 'Erinnerungsbox', 'Mini Album', 'Digitale Galerie'];
+    $checks = [];
+    foreach ($options as $option) {
+        $checks[] = '<label class="lf-checkbox"><input type="checkbox" name="options[]" value="' . htmlspecialchars($option, ENT_QUOTES) . '"><span>' . htmlspecialchars($option, ENT_QUOTES) . '</span></label>';
+    }
+    echo $successNote . render_template($template, [
+        'form_action' => '/api.php?action=form.submit&slug=' . urlencode($slug),
+        'category_options' => implode('', $categories),
+        'option_checks' => implode('', $checks),
+        'year' => date('Y')
+    ]);
+} else {
+    $template = file_get_contents(__DIR__ . '/templates/landing.html');
+    $gallery = gallery_markup($page['gallery'] ?? []);
+    $benefits = benefits_markup($page['benefits'] ?? []);
+    $pricing = pricing_markup($page['pricing'] ?? []);
+    $faq = faq_markup($page['faq'] ?? []);
+    $long = nl2br(htmlspecialchars($page['long_description'] ?? 'Unser Shooting vereint natürliche Momente, warme Farben und liebevolle Details.', ENT_QUOTES));
+    echo render_template($template, [
+        'hero_image' => htmlspecialchars($page['hero_image'] ?? '/assets/images/landing-hero.jpg', ENT_QUOTES),
+        'hero_badge' => 'Liebesblick Fotografie',
+        'title' => htmlspecialchars($page['title'] ?? '', ENT_QUOTES),
+        'subtitle' => htmlspecialchars($page['subtitle'] ?? '', ENT_QUOTES),
+        'hero_text' => htmlspecialchars($page['intro'] ?? 'Festliche Mini-Shootings mit viel Herz.', ENT_QUOTES),
+        'gallery_items' => $gallery,
+        'benefit_items' => $benefits,
+        'long_description' => $long,
+        'pricing_items' => $pricing,
+        'faq_items' => $faq,
+        'form_url' => '/form/' . htmlspecialchars($page['slug'] ?? '', ENT_QUOTES)
+    ]);
+}
+?>
+<div class="consent-banner" data-version="<?= $consentVersion ?>">
+  <p>Wir verwenden ausschließlich notwendige Cookies. Mehr erfährst du in unserer <a href="/datenschutz" style="color:#fff;text-decoration:underline;">Datenschutzerklärung</a>.</p>
+  <button class="consent-accept">Zustimmen</button>
+</div>
+<script src="/assets/app.js" defer></script>
+</body>
+</html>

--- a/templates/form.html
+++ b/templates/form.html
@@ -1,0 +1,55 @@
+<section class="lf-shell">
+  <header class="lf-header">
+    <img src="assets/images/logo.svg" alt="Liebesblick" class="lf-logo">
+    <h1 class="lf-title">Kontakt aufnehmen</h1>
+    <p class="lf-subtitle">Sichere dir deine Session – wir melden uns innerhalb von 24 Stunden.</p>
+  </header>
+  <form class="lf-form" method="post" action="{{form_action}}">
+    <div class="lf-field-row">
+      <label class="lf-label">Wie heißt du?</label>
+      <input class="lf-input" name="name" type="text" maxlength="80" required>
+    </div>
+    <div class="lf-field-row">
+      <label class="lf-label">Deine Wunsch-E-Mail?</label>
+      <input class="lf-input" name="email" type="email" maxlength="120" required>
+    </div>
+    <div class="lf-field-row">
+      <label class="lf-label">Für welches Shooting interessierst du dich?</label>
+      <select class="lf-input" name="category">
+        {{category_options}}
+      </select>
+    </div>
+    <div class="lf-field-row">
+      <label class="lf-label">Wie hast du von uns erfahren?</label>
+      <input class="lf-input" name="source" type="text" maxlength="100">
+    </div>
+    <div class="lf-field-row">
+      <label class="lf-label">Wer darf dabei sein?</label>
+      <textarea class="lf-textarea" name="details" rows="3" maxlength="300"></textarea>
+    </div>
+    <div class="lf-field-row">
+      <label class="lf-label">Wähle deinen Termin</label>
+      <input class="lf-input" name="date" type="date">
+    </div>
+    <div class="lf-field-row lf-checkboxes">
+      <label class="lf-label">Welche Optionen interessieren dich?</label>
+      <div class="lf-checkbox-grid">
+        {{option_checks}}
+      </div>
+    </div>
+    <div class="lf-field-row">
+      <label class="lf-label">Nachricht</label>
+      <textarea class="lf-textarea" name="message" rows="4" maxlength="500"></textarea>
+    </div>
+    <div class="lf-consent">
+      <label class="lf-consent-label">
+        <input type="checkbox" name="privacy" required>
+        <span>Ich stimme der Verarbeitung meiner Daten gemäß der <a href="/datenschutz">Datenschutzerklärung</a> zu.</span>
+      </label>
+    </div>
+    <button class="lf-submit" type="submit">Nachricht senden</button>
+  </form>
+  <footer class="lf-footer">
+    <p>© {{year}} Liebesblick Fotografie | Natürlich Delina Hartmann</p>
+  </footer>
+</section>

--- a/templates/landing.html
+++ b/templates/landing.html
@@ -1,0 +1,43 @@
+<section class="lp-shell">
+  <div class="lp-hero" style="background-image:url('{{hero_image}}');">
+    <div class="lp-hero-inner">
+      <p class="lp-hero-badge">{{hero_badge}}</p>
+      <h1 class="lp-hero-title">{{title}}</h1>
+      <h2 class="lp-hero-subtitle">{{subtitle}}</h2>
+      <p class="lp-hero-text">{{hero_text}}</p>
+      <a class="lp-button" href="{{form_url}}">Termin sichern</a>
+    </div>
+  </div>
+  <div class="lp-section lp-gallery">
+    <h3 class="lp-section-title">Galerie</h3>
+    <div class="lp-gallery-grid">
+      {{gallery_items}}
+    </div>
+  </div>
+  <div class="lp-section lp-benefits">
+    <h3 class="lp-section-title">Warum ihr uns lieben werdet</h3>
+    <div class="lp-benefit-grid">
+      {{benefit_items}}
+    </div>
+  </div>
+  <div class="lp-section lp-textblock">
+    <h3 class="lp-section-title">Details zum Shooting</h3>
+    <div class="lp-textblock-content">{{long_description}}</div>
+  </div>
+  <div class="lp-section lp-pricing">
+    <h3 class="lp-section-title">Preise</h3>
+    <div class="lp-pricing-grid">
+      {{pricing_items}}
+    </div>
+  </div>
+  <div class="lp-section lp-faq">
+    <h3 class="lp-section-title">FAQ</h3>
+    <div class="lp-faq-items">
+      {{faq_items}}
+    </div>
+  </div>
+  <div class="lp-section lp-cta">
+    <p class="lp-cta-text">Bereit für eure Weihnachtsmagie?</p>
+    <a class="lp-button" href="{{form_url}}">Jetzt Shooting buchen</a>
+  </div>
+</section>


### PR DESCRIPTION
## Summary
- add PHP front-end router that renders home, portfolio, landing, form, legal, sitemap, and robots routes from JSON content with SEO metadata, schema.org, hreflang, and GDPR consent banner
- create secure admin dashboard with login, CSRF, rate limiting, OpenAI configuration, and full CRUD for landing definitions using JSON storage
- expose API endpoints for consent logging, AI-assisted copy generation, GDPR requests, and form submissions plus shared CSS/JS/assets/templates/data to honour the provided palette and layouts

## Testing
- php -l index.php
- php -l admin.php
- php -l api.php

------
https://chatgpt.com/codex/tasks/task_e_68d82c449c8c8322ad3135c2ea442143