### PR TITLE
Add comprehensive booking management platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,48 @@
-test1
-=====
+# Booking & Appointment Management System
+
+Este proyecto proporciona un sistema completo de gestión de reservas/citas construido en PHP con MySQL siguiendo prácticas de producción.
+
+## Características clave
+
+- Instalador automático que crea la base de datos, usuario admin y configuración.
+- Arquitectura basada en PDO con prepared statements, transacciones y manejo robusto de errores.
+- Formularios públicos con validación y verificación de disponibilidad en tiempo real.
+- Panel administrativo seguro con autenticación, CSRF, filtros y exportación de datos.
+- API RESTful con endpoints públicos y privados para integraciones.
+- Registro completo de actividad y soporte para tokens de reserva/QR.
+- Scripts de backup/restauración y documentación del esquema.
+
+## Requisitos
+
+- PHP 8.1+
+- Extensiones `pdo`, `pdo_mysql`, `json`
+- Servidor MySQL 5.7+ o MariaDB 10.2+
+- Servidor web (Apache/Nginx) configurado para servir la carpeta `public/`
+
+## Instalación
+
+1. Clona el repositorio y da permisos de escritura a `config/` y `storage/`.
+2. Accede a `install.php` desde el navegador y completa los datos solicitados.
+3. Elimina `install.php` tras la instalación por seguridad.
+4. Accede al panel admin mediante `/admin/login.php`.
+
+## Backups
+
+Utiliza `scripts/backup.sh config/config.php` para generar copias de seguridad comprimidas.
+
+## Desarrollo
+
+- Toda interacción con la base de datos se realiza mediante `Database` (`includes/db.php`).
+- Los repositorios en `src/Repositories` encapsulan las consultas principales.
+- Los servicios en `src/Services` contienen la lógica de negocio.
+
+## Seguridad
+
+- Autenticación por sesión con cookies seguras.
+- Tokens CSRF en formularios administrativos.
+- Tokens únicos generados con `random_bytes`.
+- Sanitización de entrada y escape de salida HTML.
+
+## Licencia
+
+MIT

--- a/admin/auth-check.php
+++ b/admin/auth-check.php
@@ -1,0 +1,5 @@
+<?php
+require_once __DIR__ . '/../includes/helpers.php';
+require_once __DIR__ . '/../includes/auth.php';
+require_admin_auth();
+enforce_session_timeout();

--- a/admin/export.php
+++ b/admin/export.php
@@ -1,0 +1,22 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/../bootstrap.php';
+require_once __DIR__ . '/auth-check.php';
+
+header('Content-Type: text/csv; charset=utf-8');
+header('Content-Disposition: attachment; filename="bookings_' . date('Ymd_His') . '.csv"');
+
+$output = fopen('php://output', 'w');
+fputcsv($output, ['Booking ID', 'Nombre', 'Email', 'Fecha', 'Estado']);
+
+$stmt = $pdo->prepare('SELECT booking_id, customer_name, customer_email, booking_date, status FROM ' . DB_PREFIX . 'bookings ORDER BY created_at DESC LIMIT :limit');
+$stmt->bindValue(':limit', 5000, PDO::PARAM_INT);
+$stmt->execute();
+
+while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
+    fputcsv($output, $row);
+}
+
+fclose($output);
+exit;

--- a/admin/index.php
+++ b/admin/index.php
@@ -1,0 +1,96 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/../bootstrap.php';
+require_once __DIR__ . '/auth-check.php';
+require_once __DIR__ . '/../includes/auth.php';
+require_once __DIR__ . '/../src/Repositories/BookingRepository.php';
+require_once __DIR__ . '/../src/Repositories/AvailabilityRepository.php';
+require_once __DIR__ . '/../src/Repositories/SessionTypeRepository.php';
+require_once __DIR__ . '/../src/Repositories/ActivityLogRepository.php';
+require_once __DIR__ . '/../src/Services/BookingService.php';
+
+enforce_session_timeout();
+
+$bookingRepository = new BookingRepository($pdo);
+$availabilityRepository = new AvailabilityRepository($pdo);
+$sessionTypeRepository = new SessionTypeRepository($pdo);
+$activityLogRepository = new ActivityLogRepository($pdo);
+$bookingService = new BookingService($bookingRepository, $availabilityRepository, $sessionTypeRepository, $activityLogRepository);
+
+$filters = [
+    'status' => $_GET['status'] ?? null,
+    'search' => $_GET['search'] ?? null,
+];
+
+[$limit, $offset] = paginate((int) ($_GET['page'] ?? 1), 20);
+$bookings = $bookingService->listBookings($filters, $limit, $offset);
+
+$dashboardStmt = $pdo->query('SELECT status, COUNT(*) AS total FROM ' . DB_PREFIX . 'bookings GROUP BY status');
+$stats = $dashboardStmt->fetchAll();
+?>
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <title>Dashboard</title>
+    <link rel="stylesheet" href="/public/css/admin.css">
+</head>
+<body>
+    <header class="admin-header">
+        <h1>Dashboard de reservas</h1>
+        <nav>
+            <a href="/admin/index.php">Inicio</a>
+            <a href="/admin/export.php">Exportar CSV</a>
+            <a href="/admin/logout.php">Salir</a>
+        </nav>
+    </header>
+
+    <section class="stats">
+        <?php foreach ($stats as $stat): ?>
+            <div class="stat-card">
+                <span class="stat-label"><?= htmlspecialchars($stat['status'], ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></span>
+                <span class="stat-value"><?= (int) $stat['total']; ?></span>
+            </div>
+        <?php endforeach; ?>
+    </section>
+
+    <section class="filters">
+        <form method="get">
+            <select name="status">
+                <option value="">Todos</option>
+                <option value="pending" <?= (($_GET['status'] ?? '') === 'pending') ? 'selected' : ''; ?>>Pendientes</option>
+                <option value="confirmed" <?= (($_GET['status'] ?? '') === 'confirmed') ? 'selected' : ''; ?>>Confirmados</option>
+                <option value="cancelled" <?= (($_GET['status'] ?? '') === 'cancelled') ? 'selected' : ''; ?>>Cancelados</option>
+            </select>
+            <input type="search" name="search" placeholder="Buscar" value="<?= htmlspecialchars($_GET['search'] ?? '', ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?>">
+            <button type="submit">Filtrar</button>
+        </form>
+    </section>
+
+    <section class="bookings">
+        <table>
+            <thead>
+                <tr>
+                    <th>ID</th>
+                    <th>Cliente</th>
+                    <th>Email</th>
+                    <th>Fecha</th>
+                    <th>Estado</th>
+                </tr>
+            </thead>
+            <tbody>
+            <?php foreach ($bookings['data'] as $booking): ?>
+                <tr>
+                    <td><?= htmlspecialchars($booking['booking_id'], ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></td>
+                    <td><?= htmlspecialchars($booking['customer_name'], ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></td>
+                    <td><?= htmlspecialchars($booking['customer_email'], ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></td>
+                    <td><?= htmlspecialchars($booking['booking_date'], ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></td>
+                    <td><?= htmlspecialchars($booking['status'], ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></td>
+                </tr>
+            <?php endforeach; ?>
+            </tbody>
+        </table>
+    </section>
+</body>
+</html>

--- a/admin/login.php
+++ b/admin/login.php
@@ -1,0 +1,62 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/../bootstrap.php';
+require_once __DIR__ . '/../includes/auth.php';
+
+start_admin_session();
+
+if (!empty($_SESSION['admin_authenticated'])) {
+    header('Location: /admin/index.php');
+    exit;
+}
+
+$error = null;
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $token = $_POST['csrf_token'] ?? '';
+    if (!verify_csrf_token($token)) {
+        $error = 'Invalid CSRF token.';
+    } else {
+        $email = sanitize_string($_POST['email'] ?? '');
+        $password = (string) ($_POST['password'] ?? '');
+
+        if (!validate_email($email)) {
+            $error = 'Invalid credentials.';
+        } elseif (!admin_login($pdo, $email, $password)) {
+            $error = 'Invalid credentials.';
+        } else {
+            header('Location: /admin/index.php');
+            exit;
+        }
+    }
+}
+
+$token = csrf_token();
+?>
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <title>Admin Login</title>
+    <link rel="stylesheet" href="/public/css/admin.css">
+</head>
+<body>
+    <div class="login-container">
+        <h1>Panel administrativo</h1>
+        <?php if ($error): ?>
+            <div class="alert alert-danger"><?= htmlspecialchars($error, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></div>
+        <?php endif; ?>
+        <form method="post">
+            <input type="hidden" name="csrf_token" value="<?= $token; ?>">
+            <label>Email
+                <input type="email" name="email" required>
+            </label>
+            <label>Contraseña
+                <input type="password" name="password" required>
+            </label>
+            <button type="submit">Ingresar</button>
+        </form>
+    </div>
+</body>
+</html>

--- a/admin/logout.php
+++ b/admin/logout.php
@@ -1,0 +1,9 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/../bootstrap.php';
+require_once __DIR__ . '/../includes/auth.php';
+
+admin_logout();
+header('Location: /admin/login.php');
+exit;

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -1,0 +1,24 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/config/config.php';
+require_once __DIR__ . '/includes/db.php';
+require_once __DIR__ . '/includes/helpers.php';
+
+set_exception_handler(static function (Throwable $throwable): void {
+    error_log($throwable->getMessage());
+    if (defined('APP_DEBUG') && APP_DEBUG) {
+        http_response_code(500);
+        echo '<pre>' . htmlspecialchars($throwable, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') . '</pre>';
+    } else {
+        http_response_code(500);
+        echo 'An unexpected error occurred. Please try again later.';
+    }
+});
+
+if (function_exists('date_default_timezone_set') && defined('APP_TIMEZONE')) {
+    date_default_timezone_set(APP_TIMEZONE);
+}
+
+$dbInstance = Database::getInstance();
+$pdo = $dbInstance->getConnection();

--- a/config/config.php
+++ b/config/config.php
@@ -1,0 +1,2 @@
+<?php
+require_once __DIR__ . '/config.sample.php';

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -1,0 +1,26 @@
+<?php
+// Sample configuration file. install.php will generate config.php based on user input.
+
+define('DB_HOST', 'localhost');
+define('DB_NAME', 'booking_system');
+define('DB_USER', 'booking_user');
+define('DB_PASS', 'secure_password');
+define('DB_CHARSET', 'utf8mb4');
+define('DB_PREFIX', '');
+
+define('APP_ENV', 'production');
+define('APP_DEBUG', false);
+define('APP_TIMEZONE', 'UTC');
+
+define('SESSION_NAME', 'booking_admin_session');
+define('SESSION_LIFETIME', 7200);
+
+define('SMTP_HOST', '');
+define('SMTP_PORT', 587);
+define('SMTP_USER', '');
+define('SMTP_PASS', '');
+define('SMTP_ENCRYPTION', 'tls');
+
+define('BASE_URL', 'http://localhost');
+
+define('BACKUP_RETENTION', 10);

--- a/docs/SCHEMA.md
+++ b/docs/SCHEMA.md
@@ -1,0 +1,24 @@
+# Booking System Database Schema
+
+This document describes the core database objects created by `install.php`.
+
+## Tables
+
+- `settings`: Key/value storage for runtime configuration. Values that are valid JSON will be decoded automatically by the application layer.
+- `session_types`: Catalog of session types offered, including price and duration metadata.
+- `bookings`: Master record for reservations. Uses tokens for secure lookup and includes GDPR fields. Supports soft deletes via `deleted_at`.
+- `availability`: Stores daily availability and a JSON array of available time slots.
+- `contacts`: Contact form submissions with status tracking.
+- `email_templates`: HTML templates used for transactional email notifications.
+- `activity_logs`: Auditable actions for bookings, admin events, QR scans, emails, and system tasks.
+- `found_via_options`: Configurable list of lead sources for analytics.
+- `migrations`: Tracks executed schema migrations.
+- `admin_users`: Authenticated administrators with hashed passwords.
+
+## Indices
+
+Indexes follow the specification to optimise token lookups, status filters, and date-based queries. Foreign keys cascade `session_type_id` to `NULL` when a session type is removed to preserve booking history.
+
+## Collation
+
+All tables use `utf8mb4_unicode_ci` to fully support Unicode characters.

--- a/includes/auth.php
+++ b/includes/auth.php
@@ -1,0 +1,66 @@
+<?php
+require_once __DIR__ . '/helpers.php';
+
+function start_admin_session(): void
+{
+    if (session_status() !== PHP_SESSION_ACTIVE) {
+        session_start([
+            'cookie_httponly' => true,
+            'cookie_secure' => isset($_SERVER['HTTPS']),
+            'cookie_samesite' => 'Strict',
+            'name' => SESSION_NAME,
+        ]);
+    }
+}
+
+function admin_login(PDO $pdo, string $email, string $password): bool
+{
+    $stmt = $pdo->prepare('SELECT id, password_hash FROM ' . DB_PREFIX . 'admin_users WHERE email = :email AND active = 1');
+    $stmt->execute([':email' => strtolower($email)]);
+    $user = $stmt->fetch();
+
+    if ($user && password_verify($password, $user['password_hash'])) {
+        start_admin_session();
+
+        $_SESSION['admin_authenticated'] = true;
+        $_SESSION['admin_user_id'] = $user['id'];
+        $_SESSION['last_activity'] = time();
+
+        return true;
+    }
+
+    return false;
+}
+
+function admin_logout(): void
+{
+    if (session_status() === PHP_SESSION_ACTIVE) {
+        $_SESSION = [];
+        session_destroy();
+    }
+}
+
+function admin_session_valid(bool $renew = true): bool
+{
+    start_admin_session();
+
+    $lifetime = SESSION_LIFETIME ?? 7200;
+    if (!empty($_SESSION['last_activity']) && (time() - $_SESSION['last_activity']) > $lifetime) {
+        admin_logout();
+        return false;
+    }
+
+    if ($renew) {
+        $_SESSION['last_activity'] = time();
+    }
+
+    return !empty($_SESSION['admin_authenticated']);
+}
+
+function enforce_session_timeout(): void
+{
+    if (!admin_session_valid()) {
+        header('Location: /admin/login.php?timeout=1');
+        exit;
+    }
+}

--- a/includes/db.php
+++ b/includes/db.php
@@ -1,0 +1,50 @@
+<?php
+require_once __DIR__ . '/../config/config.php';
+
+class Database
+{
+    private static $instance = null;
+    private $pdo;
+
+    private function __construct()
+    {
+        $host = DB_HOST;
+        $dbname = DB_NAME;
+        $charset = DB_CHARSET ?? 'utf8mb4';
+        $user = DB_USER;
+        $pass = DB_PASS;
+
+        $dsn = "mysql:host={$host};dbname={$dbname};charset={$charset}";
+        $options = [
+            PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+            PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+            PDO::ATTR_EMULATE_PREPARES => false,
+            PDO::ATTR_PERSISTENT => true,
+        ];
+
+        try {
+            $this->pdo = new PDO($dsn, $user, $pass, $options);
+        } catch (PDOException $e) {
+            error_log('Database connection failed: ' . $e->getMessage());
+            throw new Exception('Database connection error');
+        }
+
+        if (defined('APP_TIMEZONE')) {
+            $this->pdo->exec("SET time_zone='" . addslashes(APP_TIMEZONE) . "'");
+        }
+    }
+
+    public static function getInstance(): self
+    {
+        if (self::$instance === null) {
+            self::$instance = new self();
+        }
+
+        return self::$instance;
+    }
+
+    public function getConnection(): PDO
+    {
+        return $this->pdo;
+    }
+}

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -1,0 +1,79 @@
+<?php
+function sanitize_string(?string $value): string
+{
+    return trim((string) $value);
+}
+
+function validate_email(string $email): bool
+{
+    return filter_var($email, FILTER_VALIDATE_EMAIL) !== false;
+}
+
+function generate_token(int $length = 32): string
+{
+    return bin2hex(random_bytes($length));
+}
+
+function csrf_token(): string
+{
+    if (session_status() !== PHP_SESSION_ACTIVE) {
+        session_start();
+    }
+
+    if (empty($_SESSION['csrf_token'])) {
+        $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
+    }
+
+    return $_SESSION['csrf_token'];
+}
+
+function verify_csrf_token(string $token): bool
+{
+    if (session_status() !== PHP_SESSION_ACTIVE) {
+        session_start();
+    }
+
+    return isset($_SESSION['csrf_token']) && hash_equals($_SESSION['csrf_token'], $token);
+}
+
+function paginate(int $page, int $perPage): array
+{
+    $page = max(1, $page);
+    $perPage = max(1, min(100, $perPage));
+    $offset = ($page - 1) * $perPage;
+
+    return [$perPage, $offset];
+}
+
+function json_response(array $data, int $status = 200): void
+{
+    http_response_code($status);
+    header('Content-Type: application/json');
+    echo json_encode($data);
+    exit;
+}
+
+function require_admin_auth(): void
+{
+    if (function_exists('admin_session_valid')) {
+        if (!admin_session_valid()) {
+            header('Location: /admin/login.php');
+            exit;
+        }
+        return;
+    }
+
+    if (session_status() !== PHP_SESSION_ACTIVE) {
+        session_start([
+            'cookie_httponly' => true,
+            'cookie_secure' => isset($_SERVER['HTTPS']),
+            'cookie_samesite' => 'Strict',
+            'name' => SESSION_NAME,
+        ]);
+    }
+
+    if (empty($_SESSION['admin_authenticated'])) {
+        header('Location: /admin/login.php');
+        exit;
+    }
+}

--- a/install.php
+++ b/install.php
@@ -1,0 +1,189 @@
+<?php
+declare(strict_types=1);
+
+$errors = [];
+$success = false;
+
+if (!extension_loaded('pdo') || !extension_loaded('pdo_mysql')) {
+    $errors[] = 'Las extensiones PDO y PDO_MySQL son requeridas.';
+}
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && !$errors) {
+    $host = trim((string) ($_POST['db_host'] ?? 'localhost'));
+    $dbName = trim((string) ($_POST['db_name'] ?? ''));
+    $dbUser = trim((string) ($_POST['db_user'] ?? ''));
+    $dbPass = (string) ($_POST['db_pass'] ?? '');
+    $dbPrefix = trim((string) ($_POST['db_prefix'] ?? ''));
+    $adminEmail = trim((string) ($_POST['admin_email'] ?? ''));
+    $adminPassword = (string) ($_POST['admin_password'] ?? '');
+    $timezone = trim((string) ($_POST['timezone'] ?? 'UTC'));
+    $smtpHost = trim((string) ($_POST['smtp_host'] ?? ''));
+    $smtpPort = (int) ($_POST['smtp_port'] ?? 587);
+    $smtpUser = trim((string) ($_POST['smtp_user'] ?? ''));
+    $smtpPass = (string) ($_POST['smtp_pass'] ?? '');
+    $smtpEncryption = trim((string) ($_POST['smtp_encryption'] ?? 'tls'));
+
+    if ($dbName === '' || $dbUser === '' || !filter_var($adminEmail, FILTER_VALIDATE_EMAIL) || $adminPassword === '') {
+        $errors[] = 'Todos los campos obligatorios deben completarse.';
+    } else {
+        try {
+            $dsn = "mysql:host={$host};charset=utf8mb4";
+            $pdo = new PDO($dsn, $dbUser, $dbPass, [
+                PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+            ]);
+
+            $pdo->exec('CREATE DATABASE IF NOT EXISTS `' . str_replace('`', '', $dbName) . "` CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci");
+
+            $dsnDb = "mysql:host={$host};dbname={$dbName};charset=utf8mb4";
+            $db = new PDO($dsnDb, $dbUser, $dbPass, [
+                PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+                PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+                PDO::ATTR_EMULATE_PREPARES => false,
+            ]);
+
+            $db->exec("SET time_zone='" . addslashes($timezone) . "'");
+
+            $tablesSql = [
+                'settings' => "CREATE TABLE IF NOT EXISTS {$dbPrefix}settings ( id INT PRIMARY KEY AUTO_INCREMENT, setting_key VARCHAR(100) UNIQUE NOT NULL, setting_value TEXT, updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_unicode_ci",
+                'session_types' => "CREATE TABLE IF NOT EXISTS {$dbPrefix}session_types ( id INT PRIMARY KEY AUTO_INCREMENT, type_id VARCHAR(50) UNIQUE NOT NULL, name VARCHAR(100) NOT NULL, description TEXT, duration VARCHAR(50), price VARCHAR(50), active BOOLEAN DEFAULT 1, sort_order INT DEFAULT 0, created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_unicode_ci",
+                'bookings' => "CREATE TABLE IF NOT EXISTS {$dbPrefix}bookings ( id INT PRIMARY KEY AUTO_INCREMENT, booking_id VARCHAR(50) UNIQUE NOT NULL, token VARCHAR(64) UNIQUE NOT NULL, qr_token VARCHAR(64) UNIQUE NOT NULL, status ENUM('pending','confirmed','cancelled') DEFAULT 'pending', customer_name VARCHAR(100) NOT NULL, customer_email VARCHAR(150) NOT NULL, customer_instagram VARCHAR(100), session_type_id INT, found_via VARCHAR(50), booking_date DATE NOT NULL, booking_time TIME, wunschtermin TEXT, message TEXT, gallery_link VARCHAR(500), gdpr_processing BOOLEAN DEFAULT 1, gdpr_marketing BOOLEAN DEFAULT 0, consent_date TIMESTAMP, ip_address VARCHAR(45), user_agent TEXT, created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP, updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP, confirmed_at TIMESTAMP NULL, cancelled_at TIMESTAMP NULL, deleted_at TIMESTAMP NULL, INDEX idx_booking_id (booking_id), INDEX idx_token (token), INDEX idx_qr_token (qr_token), INDEX idx_status (status), INDEX idx_booking_date (booking_date), INDEX idx_customer_email (customer_email), FOREIGN KEY (session_type_id) REFERENCES {$dbPrefix}session_types(id) ON DELETE SET NULL ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_unicode_ci",
+                'availability' => "CREATE TABLE IF NOT EXISTS {$dbPrefix}availability ( id INT PRIMARY KEY AUTO_INCREMENT, availability_date DATE UNIQUE NOT NULL, is_available BOOLEAN DEFAULT 1, slots JSON, notes TEXT, updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP, INDEX idx_date (availability_date) ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_unicode_ci",
+                'contacts' => "CREATE TABLE IF NOT EXISTS {$dbPrefix}contacts ( id INT PRIMARY KEY AUTO_INCREMENT, contact_id VARCHAR(50) UNIQUE NOT NULL, name VARCHAR(100) NOT NULL, email VARCHAR(150) NOT NULL, phone VARCHAR(50), subject VARCHAR(200), message TEXT, ip_address VARCHAR(45), status ENUM('new','read','responded') DEFAULT 'new', created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP, INDEX idx_status (status), INDEX idx_created (created_at) ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_unicode_ci",
+                'email_templates' => "CREATE TABLE IF NOT EXISTS {$dbPrefix}email_templates ( id INT PRIMARY KEY AUTO_INCREMENT, template_key VARCHAR(50) UNIQUE NOT NULL, template_name VARCHAR(100) NOT NULL, subject TEXT NOT NULL, body_html TEXT NOT NULL, variables JSON, active BOOLEAN DEFAULT 1, updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_unicode_ci",
+                'activity_logs' => "CREATE TABLE IF NOT EXISTS {$dbPrefix}activity_logs ( id INT PRIMARY KEY AUTO_INCREMENT, log_type ENUM('booking','admin','qr_verification','email','system') NOT NULL, action VARCHAR(100) NOT NULL, description TEXT, user_identifier VARCHAR(150), ip_address VARCHAR(45), metadata JSON, created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP, INDEX idx_type (log_type), INDEX idx_created (created_at) ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_unicode_ci",
+                'found_via_options' => "CREATE TABLE IF NOT EXISTS {$dbPrefix}found_via_options ( id INT PRIMARY KEY AUTO_INCREMENT, option_id VARCHAR(50) UNIQUE NOT NULL, name VARCHAR(100) NOT NULL, active BOOLEAN DEFAULT 1, sort_order INT DEFAULT 0 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_unicode_ci",
+                'migrations' => "CREATE TABLE IF NOT EXISTS {$dbPrefix}migrations ( id INT PRIMARY KEY AUTO_INCREMENT, version VARCHAR(20) UNIQUE NOT NULL, description VARCHAR(200), executed_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_unicode_ci",
+                'admin_users' => "CREATE TABLE IF NOT EXISTS {$dbPrefix}admin_users ( id INT PRIMARY KEY AUTO_INCREMENT, email VARCHAR(150) UNIQUE NOT NULL, password_hash VARCHAR(255) NOT NULL, active BOOLEAN DEFAULT 1, created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_unicode_ci",
+            ];
+
+            foreach ($tablesSql as $sql) {
+                $db->exec($sql);
+            }
+
+            $db->beginTransaction();
+
+            $db->prepare("INSERT IGNORE INTO {$dbPrefix}session_types (type_id, name, description, duration, price, active, sort_order) VALUES (:type_id, :name, :description, :duration, :price, 1, :sort)")
+                ->execute([':type_id' => 'standard', ':name' => 'Sesión estándar', ':description' => 'Sesión fotográfica básica', ':duration' => '60 minutos', ':price' => '150 EUR', ':sort' => 1]);
+
+            $db->prepare("INSERT IGNORE INTO {$dbPrefix}found_via_options (option_id, name, active, sort_order) VALUES (:option_id, :name, 1, :sort)")
+                ->execute([':option_id' => 'instagram', ':name' => 'Instagram', ':sort' => 1]);
+
+            $db->prepare("INSERT IGNORE INTO {$dbPrefix}settings (setting_key, setting_value) VALUES ('site_name', :value)")
+                ->execute([':value' => 'Sistema de reservas']);
+
+            $db->prepare("INSERT IGNORE INTO {$dbPrefix}email_templates (template_key, template_name, subject, body_html, variables, active) VALUES ('booking_confirmation', 'Confirmación de reserva', 'Confirmación de reserva {{booking_id}}', '<p>Hola {{customer_name}},</p><p>Tu reserva para el {{booking_date}} ha sido recibida.</p>', JSON_ARRAY('booking_id','customer_name','booking_date'), 1)")
+                ->execute();
+
+            $db->prepare("INSERT INTO {$dbPrefix}admin_users (email, password_hash) VALUES (:email, :password) ON DUPLICATE KEY UPDATE password_hash = VALUES(password_hash), active = 1")
+                ->execute([
+                    ':email' => strtolower($adminEmail),
+                    ':password' => password_hash($adminPassword, PASSWORD_BCRYPT),
+                ]);
+
+            $db->prepare("INSERT IGNORE INTO {$dbPrefix}migrations (version, description) VALUES ('1.0.0', 'Initial schema')")
+                ->execute();
+
+            $db->commit();
+
+            $configContent = "<?php\n" .
+                "define('DB_HOST', '" . addslashes($host) . "');\n" .
+                "define('DB_NAME', '" . addslashes($dbName) . "');\n" .
+                "define('DB_USER', '" . addslashes($dbUser) . "');\n" .
+                "define('DB_PASS', '" . addslashes($dbPass) . "');\n" .
+                "define('DB_CHARSET', 'utf8mb4');\n" .
+                "define('DB_PREFIX', '" . addslashes($dbPrefix) . "');\n" .
+                "define('APP_ENV', 'production');\n" .
+                "define('APP_DEBUG', false);\n" .
+                "define('APP_TIMEZONE', '" . addslashes($timezone) . "');\n" .
+                "define('SESSION_NAME', 'booking_admin_session');\n" .
+                "define('SESSION_LIFETIME', 7200);\n" .
+                "define('SMTP_HOST', '" . addslashes($smtpHost) . "');\n" .
+                "define('SMTP_PORT', " . $smtpPort . ");\n" .
+                "define('SMTP_USER', '" . addslashes($smtpUser) . "');\n" .
+                "define('SMTP_PASS', '" . addslashes($smtpPass) . "');\n" .
+                "define('SMTP_ENCRYPTION', '" . addslashes($smtpEncryption) . "');\n" .
+                "define('BASE_URL', 'http://' . \$_SERVER['HTTP_HOST']);\n" .
+                "define('BACKUP_RETENTION', 10);\n";
+
+            file_put_contents(__DIR__ . '/config/config.php', $configContent);
+
+            $tables = ['settings', 'session_types', 'bookings', 'availability', 'contacts', 'email_templates', 'activity_logs', 'found_via_options', 'migrations', 'admin_users'];
+            foreach ($tables as $table) {
+                $stmt = $db->query('SHOW TABLES LIKE ' . $db->quote($dbPrefix . $table));
+                if ($stmt->rowCount() === 0) {
+                    throw new RuntimeException('La tabla ' . $table . ' no se creó correctamente.');
+                }
+            }
+
+            $success = true;
+        } catch (Throwable $e) {
+            $errors[] = $e->getMessage();
+        }
+    }
+}
+?>
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <title>Instalador</title>
+    <link rel="stylesheet" href="/public/css/public.css">
+</head>
+<body>
+<div class="booking-form">
+    <h1>Instalador del sistema de reservas</h1>
+    <?php foreach ($errors as $error): ?>
+        <p class="error"><?= htmlspecialchars($error, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></p>
+    <?php endforeach; ?>
+    <?php if ($success): ?>
+        <p class="success">Instalación completada. Elimina install.php por seguridad.</p>
+    <?php else: ?>
+        <form method="post">
+            <label>Host MySQL
+                <input type="text" name="db_host" value="<?= htmlspecialchars($_POST['db_host'] ?? 'localhost', ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?>" required>
+            </label>
+            <label>Base de datos
+                <input type="text" name="db_name" value="<?= htmlspecialchars($_POST['db_name'] ?? '', ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?>" required>
+            </label>
+            <label>Usuario MySQL
+                <input type="text" name="db_user" value="<?= htmlspecialchars($_POST['db_user'] ?? '', ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?>" required>
+            </label>
+            <label>Contraseña MySQL
+                <input type="password" name="db_pass">
+            </label>
+            <label>Prefijo de tablas
+                <input type="text" name="db_prefix" value="<?= htmlspecialchars($_POST['db_prefix'] ?? '', ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?>">
+            </label>
+            <label>Email administrador
+                <input type="email" name="admin_email" value="<?= htmlspecialchars($_POST['admin_email'] ?? '', ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?>" required>
+            </label>
+            <label>Contraseña admin
+                <input type="password" name="admin_password" required>
+            </label>
+            <label>Timezone
+                <input type="text" name="timezone" value="<?= htmlspecialchars($_POST['timezone'] ?? 'UTC', ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?>" required>
+            </label>
+            <fieldset>
+                <legend>SMTP (opcional)</legend>
+                <label>Host SMTP
+                    <input type="text" name="smtp_host" value="<?= htmlspecialchars($_POST['smtp_host'] ?? '', ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?>">
+                </label>
+                <label>Puerto SMTP
+                    <input type="number" name="smtp_port" value="<?= (int) ($_POST['smtp_port'] ?? 587); ?>">
+                </label>
+                <label>Usuario SMTP
+                    <input type="text" name="smtp_user" value="<?= htmlspecialchars($_POST['smtp_user'] ?? '', ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?>">
+                </label>
+                <label>Contraseña SMTP
+                    <input type="password" name="smtp_pass">
+                </label>
+                <label>Encriptación
+                    <input type="text" name="smtp_encryption" value="<?= htmlspecialchars($_POST['smtp_encryption'] ?? 'tls', ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?>">
+                </label>
+            </fieldset>
+            <button type="submit">Instalar</button>
+        </form>
+    <?php endif; ?>
+</div>
+</body>
+</html>

--- a/public/api/availability.php
+++ b/public/api/availability.php
@@ -1,0 +1,27 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/../../bootstrap.php';
+require_once __DIR__ . '/../../src/Repositories/AvailabilityRepository.php';
+
+header('Access-Control-Allow-Origin: *');
+
+$date = sanitize_string($_GET['date'] ?? '');
+if (!$date) {
+    json_response(['error' => 'Date required'], 400);
+}
+
+try {
+    $availabilityRepository = new AvailabilityRepository($pdo);
+    $availability = $availabilityRepository->getByDate($date);
+
+    if (!$availability || !$availability['is_available']) {
+        json_response(['slots' => []]);
+    }
+
+    $slots = json_decode($availability['slots'] ?? '[]', true, 512, JSON_THROW_ON_ERROR);
+    json_response(['slots' => $slots]);
+} catch (Throwable $e) {
+    error_log($e->getMessage());
+    json_response(['error' => 'Server error'], 500);
+}

--- a/public/api/bookings.php
+++ b/public/api/bookings.php
@@ -1,0 +1,90 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/../../bootstrap.php';
+require_once __DIR__ . '/../../includes/auth.php';
+require_once __DIR__ . '/../../src/Repositories/BookingRepository.php';
+require_once __DIR__ . '/../../src/Repositories/AvailabilityRepository.php';
+require_once __DIR__ . '/../../src/Repositories/SessionTypeRepository.php';
+require_once __DIR__ . '/../../src/Repositories/ActivityLogRepository.php';
+require_once __DIR__ . '/../../src/Services/BookingService.php';
+
+$bookingRepository = new BookingRepository($pdo);
+$availabilityRepository = new AvailabilityRepository($pdo);
+$sessionTypeRepository = new SessionTypeRepository($pdo);
+$activityLogRepository = new ActivityLogRepository($pdo);
+$bookingService = new BookingService($bookingRepository, $availabilityRepository, $sessionTypeRepository, $activityLogRepository);
+
+$method = $_SERVER['REQUEST_METHOD'];
+
+try {
+    switch ($method) {
+        case 'GET':
+            if (!empty($_GET['token'])) {
+                $booking = $bookingRepository->findByToken(sanitize_string($_GET['token']));
+                if (!$booking) {
+                    json_response(['error' => 'Not found'], 404);
+                }
+                unset($booking['token'], $booking['qr_token']);
+                json_response(['booking' => $booking]);
+            }
+
+            start_admin_session();
+            if (!admin_session_valid()) {
+                json_response(['error' => 'Unauthorized'], 401);
+            }
+
+            [$limit, $offset] = paginate((int) ($_GET['page'] ?? 1), (int) ($_GET['limit'] ?? 20));
+            $filters = [
+                'status' => $_GET['status'] ?? null,
+                'search' => $_GET['search'] ?? null,
+            ];
+            $results = $bookingService->listBookings($filters, $limit, $offset);
+            json_response($results);
+
+        case 'POST':
+            $input = json_decode((string) file_get_contents('php://input'), true);
+            if (!is_array($input)) {
+                json_response(['error' => 'Invalid payload'], 400);
+            }
+
+            $input['ip_address'] = $_SERVER['REMOTE_ADDR'] ?? null;
+            $input['user_agent'] = $_SERVER['HTTP_USER_AGENT'] ?? null;
+
+            try {
+                $booking = $bookingService->createBooking($input);
+            } catch (InvalidArgumentException $exception) {
+                json_response(['error' => $exception->getMessage()], 400);
+            }
+
+            json_response(['booking' => $booking], 201);
+
+        case 'PATCH':
+            start_admin_session();
+            if (!admin_session_valid()) {
+                json_response(['error' => 'Unauthorized'], 401);
+            }
+
+            $input = json_decode((string) file_get_contents('php://input'), true);
+            if (!is_array($input) || empty($input['booking_id']) || empty($input['status'])) {
+                json_response(['error' => 'Invalid payload'], 400);
+            }
+
+            if ($input['status'] === 'confirmed') {
+                $bookingService->confirmBooking($input['booking_id']);
+            } elseif ($input['status'] === 'cancelled') {
+                $bookingService->cancelBooking($input['booking_id']);
+            }
+
+            json_response(['status' => 'ok']);
+
+        default:
+            header('Allow: GET, POST, PATCH', true, 405);
+            json_response(['error' => 'Method not allowed'], 405);
+    }
+} catch (InvalidArgumentException $exception) {
+    json_response(['error' => $exception->getMessage()], 400);
+} catch (Throwable $e) {
+    error_log($e->getMessage());
+    json_response(['error' => 'Server error'], 500);
+}

--- a/public/contact.php
+++ b/public/contact.php
@@ -1,0 +1,79 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/../bootstrap.php';
+require_once __DIR__ . '/../src/Repositories/ContactRepository.php';
+require_once __DIR__ . '/../src/Repositories/ActivityLogRepository.php';
+
+$contactRepository = new ContactRepository($pdo);
+$activityLogRepository = new ActivityLogRepository($pdo);
+
+$success = false;
+$errors = [];
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $name = sanitize_string($_POST['name'] ?? '');
+    $email = sanitize_string($_POST['email'] ?? '');
+    $message = sanitize_string($_POST['message'] ?? '');
+
+    if ($name === '' || $message === '' || !validate_email($email)) {
+        $errors[] = 'Todos los campos son obligatorios y el email debe ser válido.';
+    } else {
+        $contactId = strtoupper(bin2hex(random_bytes(6)));
+        $contactRepository->create([
+            'contact_id' => $contactId,
+            'name' => $name,
+            'email' => $email,
+            'phone' => sanitize_string($_POST['phone'] ?? ''),
+            'subject' => sanitize_string($_POST['subject'] ?? ''),
+            'message' => $message,
+            'ip_address' => $_SERVER['REMOTE_ADDR'] ?? null,
+        ]);
+
+        $activityLogRepository->log('system', 'contact_created', [
+            'user_identifier' => $email,
+            'metadata' => ['contact_id' => $contactId],
+        ]);
+
+        $success = true;
+    }
+}
+?>
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <title>Contacto</title>
+    <link rel="stylesheet" href="/public/css/public.css">
+</head>
+<body>
+<div class="booking-form">
+    <h1>Contacto</h1>
+    <?php foreach ($errors as $error): ?>
+        <p class="error"><?= htmlspecialchars($error, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></p>
+    <?php endforeach; ?>
+    <?php if ($success): ?>
+        <p class="success">Hemos recibido tu mensaje.</p>
+    <?php else: ?>
+        <form method="post">
+            <label>Nombre
+                <input type="text" name="name" required>
+            </label>
+            <label>Email
+                <input type="email" name="email" required>
+            </label>
+            <label>Teléfono
+                <input type="text" name="phone">
+            </label>
+            <label>Asunto
+                <input type="text" name="subject">
+            </label>
+            <label>Mensaje
+                <textarea name="message" required></textarea>
+            </label>
+            <button type="submit">Enviar</button>
+        </form>
+    <?php endif; ?>
+</div>
+</body>
+</html>

--- a/public/css/admin.css
+++ b/public/css/admin.css
@@ -1,0 +1,95 @@
+body {
+    font-family: Arial, sans-serif;
+    background: #f5f6fa;
+    margin: 0;
+    padding: 0;
+}
+
+.admin-header {
+    background: #1e272e;
+    color: #fff;
+    padding: 20px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.admin-header nav a {
+    color: #fff;
+    margin-left: 10px;
+    text-decoration: none;
+}
+
+.stats {
+    display: flex;
+    gap: 20px;
+    padding: 20px;
+}
+
+.stat-card {
+    background: #fff;
+    border-radius: 8px;
+    padding: 15px;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+    flex: 1;
+}
+
+.filters {
+    padding: 0 20px 20px 20px;
+}
+
+.bookings table {
+    width: 100%;
+    border-collapse: collapse;
+    background: #fff;
+}
+
+.bookings th, .bookings td {
+    padding: 10px;
+    border-bottom: 1px solid #ddd;
+    text-align: left;
+}
+
+.login-container {
+    max-width: 400px;
+    margin: 60px auto;
+    background: #fff;
+    padding: 30px;
+    border-radius: 8px;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.login-container h1 {
+    margin-bottom: 20px;
+}
+
+.login-container label {
+    display: block;
+    margin-bottom: 10px;
+}
+
+.login-container input {
+    width: 100%;
+    padding: 8px;
+    margin-top: 4px;
+}
+
+.login-container button {
+    margin-top: 15px;
+    padding: 10px;
+    width: 100%;
+    background: #1e272e;
+    color: #fff;
+    border: none;
+    cursor: pointer;
+}
+
+.alert {
+    padding: 10px;
+    margin-bottom: 10px;
+}
+
+.alert-danger {
+    background: #ff6b6b;
+    color: #fff;
+}

--- a/public/css/public.css
+++ b/public/css/public.css
@@ -1,0 +1,51 @@
+body {
+    font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+    background: #f9fafb;
+    margin: 0;
+    padding: 0;
+}
+
+.booking-form {
+    max-width: 600px;
+    margin: 40px auto;
+    background: #fff;
+    padding: 30px;
+    border-radius: 10px;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.08);
+}
+
+.booking-form h1 {
+    margin-bottom: 20px;
+}
+
+.booking-form label {
+    display: block;
+    margin-bottom: 15px;
+}
+
+.booking-form input,
+.booking-form select,
+.booking-form textarea {
+    width: 100%;
+    padding: 10px;
+    margin-top: 5px;
+    border: 1px solid #ccc;
+    border-radius: 5px;
+}
+
+.booking-form button {
+    padding: 12px 20px;
+    background: #0984e3;
+    color: #fff;
+    border: none;
+    border-radius: 5px;
+    cursor: pointer;
+}
+
+.success {
+    color: #2ecc71;
+}
+
+.error {
+    color: #d63031;
+}

--- a/public/index.php
+++ b/public/index.php
@@ -1,0 +1,131 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/../bootstrap.php';
+require_once __DIR__ . '/../src/Repositories/SessionTypeRepository.php';
+require_once __DIR__ . '/../src/Repositories/FoundViaRepository.php';
+require_once __DIR__ . '/../src/Repositories/AvailabilityRepository.php';
+require_once __DIR__ . '/../src/Repositories/BookingRepository.php';
+require_once __DIR__ . '/../src/Repositories/ActivityLogRepository.php';
+require_once __DIR__ . '/../src/Services/BookingService.php';
+
+$sessionTypeRepository = new SessionTypeRepository($pdo);
+$foundViaRepository = new FoundViaRepository($pdo);
+$availabilityRepository = new AvailabilityRepository($pdo);
+$bookingRepository = new BookingRepository($pdo);
+$activityLogRepository = new ActivityLogRepository($pdo);
+$bookingService = new BookingService($bookingRepository, $availabilityRepository, $sessionTypeRepository, $activityLogRepository);
+
+$sessionTypes = $sessionTypeRepository->allActive();
+$foundViaOptions = $foundViaRepository->allActive();
+
+$success = false;
+$errors = [];
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $customerName = sanitize_string($_POST['customer_name'] ?? '');
+    $customerEmail = sanitize_string($_POST['customer_email'] ?? '');
+    $sessionType = sanitize_string($_POST['session_type'] ?? '');
+    $bookingDate = sanitize_string($_POST['booking_date'] ?? '');
+    $bookingTime = sanitize_string($_POST['booking_time'] ?? '');
+
+    if ($customerName === '') {
+        $errors[] = 'El nombre es obligatorio.';
+    }
+
+    if (!validate_email($customerEmail)) {
+        $errors[] = 'El email no es válido.';
+    }
+
+    if ($bookingDate === '') {
+        $errors[] = 'La fecha es obligatoria.';
+    }
+
+    if (!$errors) {
+        try {
+            $booking = $bookingService->createBooking([
+                'customer_name' => $customerName,
+                'customer_email' => $customerEmail,
+                'customer_instagram' => sanitize_string($_POST['customer_instagram'] ?? ''),
+                'session_type_id' => $sessionType,
+                'found_via' => sanitize_string($_POST['found_via'] ?? ''),
+                'booking_date' => $bookingDate,
+                'booking_time' => $bookingTime,
+                'wunschtermin' => sanitize_string($_POST['wunschtermin'] ?? ''),
+                'message' => sanitize_string($_POST['message'] ?? ''),
+                'gdpr_marketing' => !empty($_POST['gdpr_marketing']),
+                'ip_address' => $_SERVER['REMOTE_ADDR'] ?? null,
+                'user_agent' => $_SERVER['HTTP_USER_AGENT'] ?? null,
+            ]);
+            $success = true;
+        } catch (Throwable $e) {
+            $errors[] = $e->getMessage();
+        }
+    }
+}
+?>
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <title>Reservar sesión</title>
+    <link rel="stylesheet" href="/public/css/public.css">
+</head>
+<body>
+    <main class="booking-form">
+        <h1>Reserva tu sesión</h1>
+        <?php if ($success): ?>
+            <p class="success">¡Reserva realizada! Recibirás un email de confirmación.</p>
+        <?php else: ?>
+            <?php foreach ($errors as $error): ?>
+                <p class="error"><?= htmlspecialchars($error, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></p>
+            <?php endforeach; ?>
+            <form method="post" id="bookingForm">
+                <label>Nombre completo
+                    <input type="text" name="customer_name" required>
+                </label>
+                <label>Email
+                    <input type="email" name="customer_email" required>
+                </label>
+                <label>Instagram
+                    <input type="text" name="customer_instagram">
+                </label>
+                <label>Tipo de sesión
+                    <select name="session_type" required>
+                        <option value="">Seleccionar</option>
+                        <?php foreach ($sessionTypes as $sessionType): ?>
+                            <option value="<?= htmlspecialchars($sessionType['type_id'], ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?>">
+                                <?= htmlspecialchars($sessionType['name'], ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?>
+                            </option>
+                        <?php endforeach; ?>
+                    </select>
+                </label>
+                <label>¿Cómo nos encontraste?
+                    <select name="found_via">
+                        <option value="">Seleccionar</option>
+                        <?php foreach ($foundViaOptions as $option): ?>
+                            <option value="<?= htmlspecialchars($option['option_id'], ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?>">
+                                <?= htmlspecialchars($option['name'], ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?>
+                            </option>
+                        <?php endforeach; ?>
+                    </select>
+                </label>
+                <label>Fecha deseada
+                    <input type="date" name="booking_date" id="bookingDate" required>
+                </label>
+                <label>Hora disponible
+                    <select name="booking_time" id="bookingTime"></select>
+                </label>
+                <label>Notas adicionales
+                    <textarea name="message"></textarea>
+                </label>
+                <label>
+                    <input type="checkbox" name="gdpr_marketing" value="1"> Deseo recibir novedades.
+                </label>
+                <button type="submit">Reservar</button>
+            </form>
+        <?php endif; ?>
+    </main>
+    <script src="/public/js/booking.js"></script>
+</body>
+</html>

--- a/public/js/booking.js
+++ b/public/js/booking.js
@@ -1,0 +1,47 @@
+(function () {
+    const dateInput = document.getElementById('bookingDate');
+    const timeSelect = document.getElementById('bookingTime');
+
+    if (!dateInput || !timeSelect) {
+        return;
+    }
+
+    const renderSlots = (slots) => {
+        timeSelect.innerHTML = '';
+        if (!slots.length) {
+            const option = document.createElement('option');
+            option.value = '';
+            option.textContent = 'Sin horarios disponibles';
+            timeSelect.appendChild(option);
+            return;
+        }
+
+        const placeholder = document.createElement('option');
+        placeholder.value = '';
+        placeholder.textContent = 'Selecciona un horario';
+        timeSelect.appendChild(placeholder);
+
+        slots.forEach((slot) => {
+            const option = document.createElement('option');
+            option.value = slot;
+            option.textContent = slot;
+            timeSelect.appendChild(option);
+        });
+    };
+
+    dateInput.addEventListener('change', async () => {
+        const date = dateInput.value;
+        if (!date) {
+            return;
+        }
+
+        const response = await fetch(`/public/api/availability.php?date=${encodeURIComponent(date)}`);
+        if (!response.ok) {
+            renderSlots([]);
+            return;
+        }
+
+        const data = await response.json();
+        renderSlots(data.slots || []);
+    });
+})();

--- a/public/qr.php
+++ b/public/qr.php
@@ -1,0 +1,52 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/../bootstrap.php';
+require_once __DIR__ . '/../src/Repositories/BookingRepository.php';
+require_once __DIR__ . '/../src/Repositories/ActivityLogRepository.php';
+
+$qrToken = sanitize_string($_GET['token'] ?? '');
+
+if ($qrToken === '') {
+    http_response_code(400);
+    echo 'Token requerido';
+    exit;
+}
+
+$bookingRepository = new BookingRepository($pdo);
+$activityLogRepository = new ActivityLogRepository($pdo);
+$booking = $bookingRepository->findByQrToken($qrToken);
+
+if (!$booking) {
+    http_response_code(404);
+    echo 'Reserva no encontrada';
+    exit;
+}
+
+$activityLogRepository->log('qr_verification', 'scan', [
+    'description' => 'QR escaneado',
+    'metadata' => ['booking_id' => $booking['booking_id']],
+    'ip_address' => $_SERVER['REMOTE_ADDR'] ?? null,
+]);
+
+if (!empty($booking['gallery_link'])) {
+    header('Location: ' . $booking['gallery_link']);
+    exit;
+}
+?>
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <title>QR verificado</title>
+    <link rel="stylesheet" href="/public/css/public.css">
+</head>
+<body>
+    <div class="booking-form">
+        <h1>Reserva verificada</h1>
+        <p>Cliente: <?= htmlspecialchars($booking['customer_name'], ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></p>
+        <p>Fecha: <?= htmlspecialchars($booking['booking_date'], ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></p>
+        <p>Estado: <?= htmlspecialchars($booking['status'], ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></p>
+    </div>
+</body>
+</html>

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+set -euo pipefail
+
+if [ -z "${1:-}" ]; then
+  echo "Uso: ./scripts/backup.sh <ruta_config_php>"
+  exit 1
+fi
+
+CONFIG_FILE="$1"
+if [ ! -f "$CONFIG_FILE" ]; then
+  echo "Config no encontrada"
+  exit 1
+fi
+
+mapfile -t CONFIG_VALUES < <(php -r "require '${CONFIG_FILE}'; echo DB_HOST, PHP_EOL, DB_USER, PHP_EOL, DB_PASS, PHP_EOL, DB_NAME, PHP_EOL, (defined('BACKUP_RETENTION') ? BACKUP_RETENTION : 10);")
+DB_HOST="${CONFIG_VALUES[0]}"
+DB_USER="${CONFIG_VALUES[1]}"
+DB_PASS="${CONFIG_VALUES[2]}"
+DB_NAME="${CONFIG_VALUES[3]}"
+BACKUP_RETENTION="${CONFIG_VALUES[4]}"
+
+TIMESTAMP=$(date +"%Y%m%d%H%M%S")
+BACKUP_DIR="storage/backups"
+mkdir -p "$BACKUP_DIR"
+
+mysqldump -h "$DB_HOST" -u "$DB_USER" -p"$DB_PASS" "$DB_NAME" | gzip > "$BACKUP_DIR/backup_${TIMESTAMP}.sql.gz"
+
+ls -1t "$BACKUP_DIR"/backup_*.sql.gz | tail -n +$((BACKUP_RETENTION + 1)) | xargs -r rm --

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -euo pipefail
+
+if [ $# -lt 2 ]; then
+  echo "Uso: ./scripts/restore.sh <ruta_config_php> <archivo_backup>"
+  exit 1
+fi
+
+CONFIG_FILE="$1"
+BACKUP_FILE="$2"
+
+if [ ! -f "$CONFIG_FILE" ] || [ ! -f "$BACKUP_FILE" ]; then
+  echo "Config o backup no encontrados"
+  exit 1
+fi
+
+mapfile -t CONFIG_VALUES < <(php -r "require '${CONFIG_FILE}'; echo DB_HOST, PHP_EOL, DB_USER, PHP_EOL, DB_PASS, PHP_EOL, DB_NAME;")
+DB_HOST="${CONFIG_VALUES[0]}"
+DB_USER="${CONFIG_VALUES[1]}"
+DB_PASS="${CONFIG_VALUES[2]}"
+DB_NAME="${CONFIG_VALUES[3]}"
+
+gunzip -c "$BACKUP_FILE" | mysql -h "$DB_HOST" -u "$DB_USER" -p"$DB_PASS" "$DB_NAME"

--- a/src/Repositories/ActivityLogRepository.php
+++ b/src/Repositories/ActivityLogRepository.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+class ActivityLogRepository
+{
+    private PDO $pdo;
+
+    public function __construct(PDO $pdo)
+    {
+        $this->pdo = $pdo;
+    }
+
+    public function log(string $type, string $action, array $data = []): void
+    {
+        $stmt = $this->pdo->prepare(
+            "INSERT INTO " . DB_PREFIX . "activity_logs (log_type, action, description, user_identifier, ip_address, metadata) VALUES (:log_type, :action, :description, :user_identifier, :ip_address, :metadata)"
+        );
+
+        $stmt->execute([
+            ':log_type' => $type,
+            ':action' => $action,
+            ':description' => $data['description'] ?? null,
+            ':user_identifier' => $data['user_identifier'] ?? null,
+            ':ip_address' => $data['ip_address'] ?? null,
+            ':metadata' => !empty($data['metadata']) ? json_encode($data['metadata'], JSON_THROW_ON_ERROR) : null,
+        ]);
+    }
+}

--- a/src/Repositories/AvailabilityRepository.php
+++ b/src/Repositories/AvailabilityRepository.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+class AvailabilityRepository
+{
+    private PDO $pdo;
+
+    public function __construct(PDO $pdo)
+    {
+        $this->pdo = $pdo;
+    }
+
+    public function getByDate(string $date): ?array
+    {
+        $stmt = $this->pdo->prepare(
+            "SELECT * FROM " . DB_PREFIX . "availability WHERE availability_date = :date"
+        );
+        $stmt->execute([':date' => $date]);
+        $availability = $stmt->fetch();
+
+        return $availability ?: null;
+    }
+
+    public function setAvailability(string $date, bool $isAvailable, array $slots, ?string $notes = null): void
+    {
+        $stmt = $this->pdo->prepare(
+            "INSERT INTO " . DB_PREFIX . "availability (availability_date, is_available, slots, notes) VALUES (:date, :is_available, :slots, :notes) ON DUPLICATE KEY UPDATE is_available = VALUES(is_available), slots = VALUES(slots), notes = VALUES(notes), updated_at = NOW()"
+        );
+
+        $stmt->execute([
+            ':date' => $date,
+            ':is_available' => $isAvailable ? 1 : 0,
+            ':slots' => json_encode(array_values($slots), JSON_THROW_ON_ERROR),
+            ':notes' => $notes,
+        ]);
+    }
+
+    public function removeSlot(string $date, string $slot): void
+    {
+        $stmt = $this->pdo->prepare(
+            "UPDATE " . DB_PREFIX . "availability SET slots = JSON_REMOVE(slots, JSON_UNQUOTE(JSON_SEARCH(slots, 'one', :slot))), updated_at = NOW() WHERE availability_date = :date"
+        );
+        $stmt->execute([
+            ':slot' => $slot,
+            ':date' => $date,
+        ]);
+    }
+
+    public function listBetween(string $startDate, string $endDate): array
+    {
+        $stmt = $this->pdo->prepare(
+            "SELECT * FROM " . DB_PREFIX . "availability WHERE availability_date BETWEEN :start AND :end ORDER BY availability_date"
+        );
+        $stmt->execute([
+            ':start' => $startDate,
+            ':end' => $endDate,
+        ]);
+
+        return $stmt->fetchAll();
+    }
+}

--- a/src/Repositories/BookingRepository.php
+++ b/src/Repositories/BookingRepository.php
@@ -1,0 +1,174 @@
+<?php
+
+declare(strict_types=1);
+
+class BookingRepository
+{
+    private PDO $pdo;
+
+    public function __construct(PDO $pdo)
+    {
+        $this->pdo = $pdo;
+    }
+
+    public function create(array $data): array
+    {
+        $this->pdo->beginTransaction();
+
+        try {
+            $stmt = $this->pdo->prepare(
+                "INSERT INTO " . DB_PREFIX . "bookings (booking_id, token, qr_token, status, customer_name, customer_email, customer_instagram, session_type_id, found_via, booking_date, booking_time, wunschtermin, message, gallery_link, gdpr_processing, gdpr_marketing, consent_date, ip_address, user_agent) VALUES (:booking_id, :token, :qr_token, :status, :customer_name, :customer_email, :customer_instagram, :session_type_id, :found_via, :booking_date, :booking_time, :wunschtermin, :message, :gallery_link, :gdpr_processing, :gdpr_marketing, NOW(), :ip_address, :user_agent)"
+            );
+
+            $stmt->execute([
+                ':booking_id' => $data['booking_id'],
+                ':token' => $data['token'],
+                ':qr_token' => $data['qr_token'],
+                ':status' => $data['status'] ?? 'pending',
+                ':customer_name' => $data['customer_name'],
+                ':customer_email' => $data['customer_email'],
+                ':customer_instagram' => $data['customer_instagram'] ?? null,
+                ':session_type_id' => $data['session_type_id'] ?? null,
+                ':found_via' => $data['found_via'] ?? null,
+                ':booking_date' => $data['booking_date'],
+                ':booking_time' => $data['booking_time'] ?? null,
+                ':wunschtermin' => $data['wunschtermin'] ?? null,
+                ':message' => $data['message'] ?? null,
+                ':gallery_link' => $data['gallery_link'] ?? null,
+                ':gdpr_processing' => (int) ($data['gdpr_processing'] ?? 1),
+                ':gdpr_marketing' => (int) ($data['gdpr_marketing'] ?? 0),
+                ':ip_address' => $data['ip_address'] ?? null,
+                ':user_agent' => $data['user_agent'] ?? null,
+            ]);
+
+            if (!empty($data['slot_update'])) {
+                $availabilityStmt = $this->pdo->prepare(
+                    "UPDATE " . DB_PREFIX . "availability SET slots = JSON_REMOVE(slots, JSON_UNQUOTE(JSON_SEARCH(slots, 'one', :slot))), updated_at = NOW() WHERE availability_date = :date"
+                );
+                $availabilityStmt->execute([
+                    ':slot' => $data['slot_update']['slot'],
+                    ':date' => $data['slot_update']['date'],
+                ]);
+            }
+
+            $logStmt = $this->pdo->prepare(
+                "INSERT INTO " . DB_PREFIX . "activity_logs (log_type, action, user_identifier, ip_address, metadata) VALUES ('booking', 'created', :user_identifier, :ip_address, :metadata)"
+            );
+            $logStmt->execute([
+                ':user_identifier' => $data['customer_email'],
+                ':ip_address' => $data['ip_address'] ?? null,
+                ':metadata' => json_encode(['booking_id' => $data['booking_id']], JSON_THROW_ON_ERROR),
+            ]);
+
+            $this->pdo->commit();
+
+            return $this->findByBookingId($data['booking_id']);
+        } catch (Throwable $e) {
+            $this->pdo->rollBack();
+            throw $e;
+        }
+    }
+
+    public function findByBookingId(string $bookingId): ?array
+    {
+        $stmt = $this->pdo->prepare(
+            "SELECT b.*, st.name AS session_name FROM " . DB_PREFIX . "bookings b LEFT JOIN " . DB_PREFIX . "session_types st ON b.session_type_id = st.id WHERE b.booking_id = :booking_id"
+        );
+        $stmt->execute([':booking_id' => $bookingId]);
+        $booking = $stmt->fetch();
+
+        return $booking ?: null;
+    }
+
+    public function findByToken(string $token): ?array
+    {
+        $stmt = $this->pdo->prepare(
+            "SELECT b.*, st.name AS session_name FROM " . DB_PREFIX . "bookings b LEFT JOIN " . DB_PREFIX . "session_types st ON b.session_type_id = st.id WHERE b.token = :token"
+        );
+        $stmt->execute([':token' => $token]);
+        $booking = $stmt->fetch();
+
+        return $booking ?: null;
+    }
+
+    public function findByQrToken(string $qrToken): ?array
+    {
+        $stmt = $this->pdo->prepare(
+            "SELECT booking_id, customer_name, customer_email, session_type_id, booking_date, booking_time, status, gallery_link FROM " . DB_PREFIX . "bookings WHERE qr_token = :qr_token"
+        );
+        $stmt->execute([':qr_token' => $qrToken]);
+        $booking = $stmt->fetch();
+
+        return $booking ?: null;
+    }
+
+    public function updateStatus(string $bookingId, string $status): bool
+    {
+        $validStatuses = ['pending', 'confirmed', 'cancelled'];
+        if (!in_array($status, $validStatuses, true)) {
+            throw new InvalidArgumentException('Invalid status');
+        }
+
+        $timestampColumn = match ($status) {
+            'confirmed' => 'confirmed_at',
+            'cancelled' => 'cancelled_at',
+            default => null,
+        };
+
+        $columns = "status = :status";
+        if ($timestampColumn) {
+            $columns .= ", {$timestampColumn} = NOW()";
+        }
+
+        $stmt = $this->pdo->prepare(
+            "UPDATE " . DB_PREFIX . "bookings SET {$columns} WHERE booking_id = :booking_id"
+        );
+
+        return $stmt->execute([
+            ':status' => $status,
+            ':booking_id' => $bookingId,
+        ]);
+    }
+
+    public function paginate(array $filters, int $limit, int $offset): array
+    {
+        $where = ['1=1'];
+        $params = [];
+
+        if (!empty($filters['status'])) {
+            $where[] = 'b.status = :status';
+            $params[':status'] = $filters['status'];
+        }
+
+        if (!empty($filters['search'])) {
+            $where[] = '(b.customer_name LIKE :search OR b.customer_email LIKE :search)';
+            $params[':search'] = '%' . $filters['search'] . '%';
+        }
+
+        if (!empty($filters['date_from'])) {
+            $where[] = 'b.booking_date >= :date_from';
+            $params[':date_from'] = $filters['date_from'];
+        }
+
+        if (!empty($filters['date_to'])) {
+            $where[] = 'b.booking_date <= :date_to';
+            $params[':date_to'] = $filters['date_to'];
+        }
+
+        $sql = "SELECT SQL_CALC_FOUND_ROWS b.*, st.name AS session_name FROM " . DB_PREFIX . "bookings b LEFT JOIN " . DB_PREFIX . "session_types st ON b.session_type_id = st.id WHERE " . implode(' AND ', $where) . " ORDER BY b.created_at DESC LIMIT :limit OFFSET :offset";
+
+        $stmt = $this->pdo->prepare($sql);
+        foreach ($params as $key => $value) {
+            $stmt->bindValue($key, $value);
+        }
+        $stmt->bindValue(':limit', $limit, PDO::PARAM_INT);
+        $stmt->bindValue(':offset', $offset, PDO::PARAM_INT);
+        $stmt->execute();
+        $bookings = $stmt->fetchAll();
+
+        $countStmt = $this->pdo->query('SELECT FOUND_ROWS() AS total');
+        $total = (int) $countStmt->fetchColumn();
+
+        return ['data' => $bookings, 'total' => $total];
+    }
+}

--- a/src/Repositories/ContactRepository.php
+++ b/src/Repositories/ContactRepository.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+class ContactRepository
+{
+    private PDO $pdo;
+
+    public function __construct(PDO $pdo)
+    {
+        $this->pdo = $pdo;
+    }
+
+    public function create(array $data): void
+    {
+        $stmt = $this->pdo->prepare(
+            "INSERT INTO " . DB_PREFIX . "contacts (contact_id, name, email, phone, subject, message, ip_address, status) VALUES (:contact_id, :name, :email, :phone, :subject, :message, :ip_address, :status)"
+        );
+        $stmt->execute([
+            ':contact_id' => $data['contact_id'],
+            ':name' => $data['name'],
+            ':email' => $data['email'],
+            ':phone' => $data['phone'] ?? null,
+            ':subject' => $data['subject'] ?? null,
+            ':message' => $data['message'],
+            ':ip_address' => $data['ip_address'] ?? null,
+            ':status' => $data['status'] ?? 'new',
+        ]);
+    }
+}

--- a/src/Repositories/EmailTemplateRepository.php
+++ b/src/Repositories/EmailTemplateRepository.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+class EmailTemplateRepository
+{
+    private PDO $pdo;
+
+    public function __construct(PDO $pdo)
+    {
+        $this->pdo = $pdo;
+    }
+
+    public function findActiveByKey(string $key): ?array
+    {
+        $stmt = $this->pdo->prepare(
+            "SELECT * FROM " . DB_PREFIX . "email_templates WHERE template_key = :template_key AND active = 1"
+        );
+        $stmt->execute([':template_key' => $key]);
+        $template = $stmt->fetch();
+
+        return $template ?: null;
+    }
+
+    public function updateBody(string $key, string $subject, string $body): void
+    {
+        $stmt = $this->pdo->prepare(
+            "UPDATE " . DB_PREFIX . "email_templates SET subject = :subject, body_html = :body, updated_at = CURRENT_TIMESTAMP WHERE template_key = :template_key"
+        );
+        $stmt->execute([
+            ':subject' => $subject,
+            ':body' => $body,
+            ':template_key' => $key,
+        ]);
+    }
+}

--- a/src/Repositories/FoundViaRepository.php
+++ b/src/Repositories/FoundViaRepository.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+class FoundViaRepository
+{
+    private PDO $pdo;
+
+    public function __construct(PDO $pdo)
+    {
+        $this->pdo = $pdo;
+    }
+
+    public function allActive(): array
+    {
+        $stmt = $this->pdo->query(
+            "SELECT * FROM " . DB_PREFIX . "found_via_options WHERE active = 1 ORDER BY sort_order ASC, name ASC"
+        );
+
+        return $stmt->fetchAll();
+    }
+}

--- a/src/Repositories/MigrationRepository.php
+++ b/src/Repositories/MigrationRepository.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+class MigrationRepository
+{
+    private PDO $pdo;
+
+    public function __construct(PDO $pdo)
+    {
+        $this->pdo = $pdo;
+    }
+
+    public function hasExecuted(string $version): bool
+    {
+        $stmt = $this->pdo->prepare(
+            "SELECT COUNT(*) FROM " . DB_PREFIX . "migrations WHERE version = :version"
+        );
+        $stmt->execute([':version' => $version]);
+
+        return (bool) $stmt->fetchColumn();
+    }
+
+    public function logExecution(string $version, string $description): void
+    {
+        $stmt = $this->pdo->prepare(
+            "INSERT INTO " . DB_PREFIX . "migrations (version, description) VALUES (:version, :description)"
+        );
+        $stmt->execute([
+            ':version' => $version,
+            ':description' => $description,
+        ]);
+    }
+}

--- a/src/Repositories/SessionTypeRepository.php
+++ b/src/Repositories/SessionTypeRepository.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+class SessionTypeRepository
+{
+    private PDO $pdo;
+
+    public function __construct(PDO $pdo)
+    {
+        $this->pdo = $pdo;
+    }
+
+    public function allActive(): array
+    {
+        $stmt = $this->pdo->query(
+            "SELECT * FROM " . DB_PREFIX . "session_types WHERE active = 1 ORDER BY sort_order ASC, name ASC"
+        );
+
+        return $stmt->fetchAll();
+    }
+
+    public function findByTypeId(string $typeId): ?array
+    {
+        $stmt = $this->pdo->prepare(
+            "SELECT * FROM " . DB_PREFIX . "session_types WHERE type_id = :type_id"
+        );
+        $stmt->execute([':type_id' => $typeId]);
+        $sessionType = $stmt->fetch();
+
+        return $sessionType ?: null;
+    }
+}

--- a/src/Repositories/SettingsRepository.php
+++ b/src/Repositories/SettingsRepository.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+class SettingsRepository
+{
+    private PDO $pdo;
+    private array $cache = [];
+
+    public function __construct(PDO $pdo)
+    {
+        $this->pdo = $pdo;
+    }
+
+    public function get(string $key, mixed $default = null): mixed
+    {
+        if (isset($this->cache[$key])) {
+            return $this->cache[$key];
+        }
+
+        $stmt = $this->pdo->prepare(
+            "SELECT setting_value FROM " . DB_PREFIX . "settings WHERE setting_key = :key"
+        );
+        $stmt->execute([':key' => $key]);
+        $value = $stmt->fetchColumn();
+
+        if ($value === false) {
+            return $default;
+        }
+
+        $decoded = json_decode((string) $value, true);
+        $this->cache[$key] = json_last_error() === JSON_ERROR_NONE ? $decoded : $value;
+
+        return $this->cache[$key];
+    }
+
+    public function set(string $key, mixed $value): void
+    {
+        $encodedValue = is_array($value) ? json_encode($value, JSON_THROW_ON_ERROR) : (string) $value;
+
+        $stmt = $this->pdo->prepare(
+            "INSERT INTO " . DB_PREFIX . "settings (setting_key, setting_value) VALUES (:key, :value) ON DUPLICATE KEY UPDATE setting_value = VALUES(setting_value), updated_at = CURRENT_TIMESTAMP"
+        );
+        $stmt->execute([
+            ':key' => $key,
+            ':value' => $encodedValue,
+        ]);
+
+        $this->cache[$key] = $value;
+
+        $logStmt = $this->pdo->prepare(
+            "INSERT INTO " . DB_PREFIX . "activity_logs (log_type, action, description, metadata) VALUES ('system', 'settings_updated', :description, :metadata)"
+        );
+        $logStmt->execute([
+            ':description' => $key,
+            ':metadata' => json_encode(['key' => $key], JSON_THROW_ON_ERROR),
+        ]);
+    }
+}

--- a/src/Services/BookingService.php
+++ b/src/Services/BookingService.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+class BookingService
+{
+    private BookingRepository $bookingRepository;
+    private AvailabilityRepository $availabilityRepository;
+    private SessionTypeRepository $sessionTypeRepository;
+    private ActivityLogRepository $activityLogRepository;
+
+    public function __construct(
+        BookingRepository $bookingRepository,
+        AvailabilityRepository $availabilityRepository,
+        SessionTypeRepository $sessionTypeRepository,
+        ActivityLogRepository $activityLogRepository
+    ) {
+        $this->bookingRepository = $bookingRepository;
+        $this->availabilityRepository = $availabilityRepository;
+        $this->sessionTypeRepository = $sessionTypeRepository;
+        $this->activityLogRepository = $activityLogRepository;
+    }
+
+    public function createBooking(array $payload): array
+    {
+        $sessionType = null;
+        if (!empty($payload['session_type_id'])) {
+            $sessionType = $this->sessionTypeRepository->findByTypeId($payload['session_type_id']);
+            if (!$sessionType) {
+                throw new InvalidArgumentException('Session type not found');
+            }
+        }
+
+        if (empty($payload['customer_name'])) {
+            throw new InvalidArgumentException('Customer name is required');
+        }
+
+        if (empty($payload['customer_email']) || !validate_email((string) $payload['customer_email'])) {
+            throw new InvalidArgumentException('A valid email address is required');
+        }
+
+        $bookingId = strtoupper(bin2hex(random_bytes(5)));
+        $token = generate_token(16);
+        $qrToken = generate_token(16);
+
+        if (empty($payload['booking_date'])) {
+            throw new InvalidArgumentException('Booking date is required');
+        }
+
+        $availability = $this->availabilityRepository->getByDate($payload['booking_date']);
+        if (!$availability || !$availability['is_available']) {
+            throw new InvalidArgumentException('Date not available');
+        }
+
+        $slots = json_decode($availability['slots'] ?? '[]', true, 512, JSON_THROW_ON_ERROR);
+        if (!empty($payload['booking_time']) && !in_array($payload['booking_time'], $slots, true)) {
+            throw new InvalidArgumentException('Time slot not available');
+        }
+
+        $booking = $this->bookingRepository->create([
+            'booking_id' => $bookingId,
+            'token' => $token,
+            'qr_token' => $qrToken,
+            'status' => 'pending',
+            'customer_name' => sanitize_string($payload['customer_name']),
+            'customer_email' => $payload['customer_email'],
+            'customer_instagram' => $payload['customer_instagram'] ?? null,
+            'session_type_id' => $sessionType['id'] ?? null,
+            'found_via' => $payload['found_via'] ?? null,
+            'booking_date' => $payload['booking_date'],
+            'booking_time' => $payload['booking_time'] ?? null,
+            'wunschtermin' => $payload['wunschtermin'] ?? null,
+            'message' => $payload['message'] ?? null,
+            'gallery_link' => null,
+            'gdpr_processing' => true,
+            'gdpr_marketing' => !empty($payload['gdpr_marketing']),
+            'ip_address' => $payload['ip_address'] ?? null,
+            'user_agent' => $payload['user_agent'] ?? null,
+            'slot_update' => !empty($payload['booking_time']) ? [
+                'date' => $payload['booking_date'],
+                'slot' => $payload['booking_time'],
+            ] : null,
+        ]);
+
+        $this->activityLogRepository->log('booking', 'queued_email', [
+            'user_identifier' => $payload['customer_email'],
+            'metadata' => ['booking_id' => $bookingId, 'type' => 'confirmation'],
+        ]);
+
+        return $booking;
+    }
+
+    public function confirmBooking(string $bookingId): void
+    {
+        if ($this->bookingRepository->updateStatus($bookingId, 'confirmed')) {
+            $this->activityLogRepository->log('booking', 'status_changed', [
+                'description' => 'Booking confirmed',
+                'metadata' => ['booking_id' => $bookingId, 'status' => 'confirmed'],
+            ]);
+        }
+    }
+
+    public function cancelBooking(string $bookingId): void
+    {
+        if ($this->bookingRepository->updateStatus($bookingId, 'cancelled')) {
+            $this->activityLogRepository->log('booking', 'status_changed', [
+                'description' => 'Booking cancelled',
+                'metadata' => ['booking_id' => $bookingId, 'status' => 'cancelled'],
+            ]);
+        }
+    }
+
+    public function listBookings(array $filters, int $limit, int $offset): array
+    {
+        return $this->bookingRepository->paginate($filters, $limit, $offset);
+    }
+}

--- a/src/Services/EmailService.php
+++ b/src/Services/EmailService.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+class EmailService
+{
+    private EmailTemplateRepository $templateRepository;
+    private ActivityLogRepository $activityLogRepository;
+
+    public function __construct(EmailTemplateRepository $templateRepository, ActivityLogRepository $activityLogRepository)
+    {
+        $this->templateRepository = $templateRepository;
+        $this->activityLogRepository = $activityLogRepository;
+    }
+
+    public function sendTemplate(string $templateKey, array $variables, string $toEmail): void
+    {
+        $template = $this->templateRepository->findActiveByKey($templateKey);
+        if (!$template) {
+            throw new RuntimeException('Template not found');
+        }
+
+        $subject = $this->parseVariables($template['subject'], $variables);
+        $body = $this->parseVariables($template['body_html'], $variables);
+
+        $headers = "MIME-Version: 1.0\r\n";
+        $headers .= "Content-type:text/html;charset=UTF-8\r\n";
+        if (!empty(SMTP_USER)) {
+            $headers .= 'From: ' . SMTP_USER . "\r\n";
+        }
+
+        if (!mail($toEmail, $subject, $body, $headers)) {
+            throw new RuntimeException('Failed to send email');
+        }
+
+        $this->activityLogRepository->log('email', 'sent', [
+            'user_identifier' => $toEmail,
+            'metadata' => ['template' => $templateKey],
+        ]);
+    }
+
+    private function parseVariables(string $content, array $variables): string
+    {
+        return (string) preg_replace_callback('/{{\s*(.*?)\s*}}/', static function ($matches) use ($variables) {
+            $key = $matches[1];
+            return htmlspecialchars((string) ($variables[$key] ?? ''), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+        }, $content);
+    }
+}

--- a/tests/query-tests.sql
+++ b/tests/query-tests.sql
@@ -1,0 +1,4 @@
+-- Sample query tests for performance verification
+EXPLAIN SELECT * FROM bookings WHERE booking_date = CURDATE();
+EXPLAIN SELECT * FROM bookings WHERE booking_id = 'SAMPLE';
+EXPLAIN SELECT * FROM activity_logs WHERE log_type = 'booking' ORDER BY created_at DESC LIMIT 20;


### PR DESCRIPTION
## Summary
- add a production-ready installer that provisions the full MySQL schema, seeds defaults, and writes environment configuration
- implement repositories, services, REST APIs, and public views for bookings, availability checks, contacts, and QR verification
- deliver an authenticated admin dashboard with export tools plus backup/restore scripts and documentation for operations

## Testing
- php -l install.php
- php -l public/api/bookings.php
- php -l includes/auth.php
- php -l public/index.php
- php -l admin/index.php

------
https://chatgpt.com/codex/tasks/task_e_68e276e574cc832285b9e14f65b379a2